### PR TITLE
Add support for finite object distances

### DIFF
--- a/tests/opticstudio/analysis/test_raytrace.py
+++ b/tests/opticstudio/analysis/test_raytrace.py
@@ -49,7 +49,9 @@ class TestRayTraceAnalysis:
         opticstudio_backend,
         opticstudio_analysis,
     ):
-        opticstudio_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
+        opticstudio_backend.build_model(
+            EyeModel(), object_distance=10 if field_type == "object_height" else float("inf")
+        )
 
         args = build_args(
             non_null_defaults={"field_type", "pupil"},

--- a/tests/opticstudio/analysis/test_raytrace.py
+++ b/tests/opticstudio/analysis/test_raytrace.py
@@ -22,7 +22,6 @@ class TestRayTraceAnalysis:
                 "object_height",
                 (1, 0),
                 does_not_raise(),
-                marks=pytest.mark.xfail(reason="ZOSPy cannot parse ray trace results when field_type is object_height"),
             ),
             (
                 [(0, 0), (1, 1)],
@@ -50,7 +49,7 @@ class TestRayTraceAnalysis:
         opticstudio_backend,
         opticstudio_analysis,
     ):
-        opticstudio_backend.build_model(EyeModel())
+        opticstudio_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
 
         args = build_args(
             non_null_defaults={"field_type", "pupil"},

--- a/tests/opticstudio/analysis/test_refraction.py
+++ b/tests/opticstudio/analysis/test_refraction.py
@@ -3,6 +3,7 @@ import math
 import pytest
 
 from tests.helpers import build_args
+from visisipy.models import EyeModel
 from visisipy.types import SampleSize
 
 pytestmark = [pytest.mark.needs_opticstudio]
@@ -48,7 +49,7 @@ class TestRefractionAnalysis:
                 0.5,
                 "object_height",
                 None,
-                marks=pytest.mark.xfail(reason="ZOSPy cannot parse Zernike results when field_type is object_height"),
+                # marks=pytest.mark.xfail(reason="ZOSPy cannot parse Zernike results when field_type is object_height"),
             ),
             ((0, 0), 0.543, "32x32", 0.5, "angle", True),
             pytest.param(
@@ -58,7 +59,7 @@ class TestRefractionAnalysis:
                 0.5,
                 "object_height",
                 False,
-                marks=pytest.mark.xfail(reason="ZOSPy cannot parse Zernike results when field_type is object_height"),
+                # marks=pytest.mark.xfail(reason="ZOSPy cannot parse Zernike results when field_type is object_height"),
             ),
         ],
     )
@@ -71,9 +72,11 @@ class TestRefractionAnalysis:
         field_type,
         use_higher_order_aberrations,
         opticstudio_analysis,
+        opticstudio_backend,
         monkeypatch,
     ):
-        monkeypatch.setattr(opticstudio_analysis.backend, "model", MockOpticstudioModel())
+        opticstudio_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
+        # monkeypatch.setattr(opticstudio_analysis.backend, "model", MockOpticstudioModel())
 
         args = build_args(
             field_coordinate=field_coordinate,

--- a/tests/opticstudio/analysis/test_refraction.py
+++ b/tests/opticstudio/analysis/test_refraction.py
@@ -75,7 +75,9 @@ class TestRefractionAnalysis:
         opticstudio_backend,
         monkeypatch,
     ):
-        opticstudio_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
+        opticstudio_backend.build_model(
+            EyeModel(), object_distance=10 if field_type == "object_height" else float("inf")
+        )
         # monkeypatch.setattr(opticstudio_analysis.backend, "model", MockOpticstudioModel())
 
         args = build_args(

--- a/tests/opticstudio/analysis/test_zernike_coefficients.py
+++ b/tests/opticstudio/analysis/test_zernike_coefficients.py
@@ -36,7 +36,9 @@ class TestZernikeStandardCoefficientsAnalysis:
         opticstudio_backend,
         opticstudio_analysis,
     ):
-        opticstudio_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
+        opticstudio_backend.build_model(
+            EyeModel(), object_distance=10 if field_type == "object_height" else float("inf")
+        )
 
         args = build_args(
             field_coordinate=field_coordinate,

--- a/tests/opticstudio/analysis/test_zernike_coefficients.py
+++ b/tests/opticstudio/analysis/test_zernike_coefficients.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.helpers import build_args
+from visisipy.models import EyeModel
 from visisipy.types import SampleSize
 
 pytestmark = [pytest.mark.needs_opticstudio]
@@ -19,7 +20,7 @@ class TestZernikeStandardCoefficientsAnalysis:
                 "object_height",
                 64,
                 None,
-                marks=pytest.mark.xfail(reason="ZOSPy cannot parse Zernike results when field_type is object_height"),
+                # marks=pytest.mark.xfail(reason="ZOSPy cannot parse Zernike results when field_type is object_height"),
             ),
             ((0, 0), 0.543, "angle", SampleSize(64), 45),
             ((1, 1), 0.632, "angle", "64x64", 100),
@@ -32,8 +33,11 @@ class TestZernikeStandardCoefficientsAnalysis:
         field_type,
         sampling,
         maximum_term,
+        opticstudio_backend,
         opticstudio_analysis,
     ):
+        opticstudio_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
+
         args = build_args(
             field_coordinate=field_coordinate,
             wavelength=wavelength,

--- a/tests/opticstudio/test_models.py
+++ b/tests/opticstudio/test_models.py
@@ -92,11 +92,8 @@ class TestOpticStudioEye:
     def test_build_start_from_index_after_stop_surface_raises_valueerror(self, new_oss, eye_model):
         opticstudio_eye = OpticStudioEye(eye_model)
 
-        with pytest.raises(
-            ValueError, match="'start_from_index' must be smaller than the index of the stop surface"
-        ):
+        with pytest.raises(ValueError, match="'start_from_index' must be smaller than the index of the stop surface"):
             opticstudio_eye.build(new_oss, start_from_index=1)
-
 
     def test_build_replace_existing(self, new_oss, eye_model):
         opticstudio_eye = OpticStudioEye(eye_model)

--- a/tests/optiland/analysis/test_raytrace.py
+++ b/tests/optiland/analysis/test_raytrace.py
@@ -20,7 +20,6 @@ class TestRayTraceAnalysis:
                 "object_height",
                 (1, 0),
                 does_not_raise(),
-                marks=pytest.mark.xfail(reason="Finite object distances are not yet supported"),
             ),
             (
                 [(0, 0), (1, 1)],
@@ -48,7 +47,7 @@ class TestRayTraceAnalysis:
         optiland_backend,
         optiland_analysis,
     ):
-        optiland_backend.build_model(EyeModel())
+        optiland_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
 
         args = build_args(
             non_null_defaults={"field_type", "pupil"},

--- a/tests/optiland/analysis/test_refraction.py
+++ b/tests/optiland/analysis/test_refraction.py
@@ -58,7 +58,6 @@ class TestRefractionAnalysis:
                 0.5,
                 "object_height",
                 None,
-                marks=pytest.mark.xfail(reason="Finite object distances are not yet supported"),
             ),
             ((0, 0), 0.543, "32x32", 0.5, "angle", True),
             pytest.param(
@@ -68,7 +67,6 @@ class TestRefractionAnalysis:
                 0.5,
                 "object_height",
                 False,
-                marks=pytest.mark.xfail(reason="Finite object distances are not yet supported"),
             ),
         ],
     )
@@ -83,7 +81,7 @@ class TestRefractionAnalysis:
         optiland_backend,
         optiland_analysis,
     ):
-        optiland_backend.build_model(EyeModel())
+        optiland_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
 
         args = build_args(
             field_coordinate=field_coordinate,

--- a/tests/optiland/analysis/test_zernike_coefficients.py
+++ b/tests/optiland/analysis/test_zernike_coefficients.py
@@ -18,7 +18,6 @@ class TestZernikeStandardCoefficientsAnalysis:
                 "object_height",
                 64,
                 None,
-                marks=pytest.mark.xfail(reason="Finite object distances are not yet supported"),
             ),
             ((0, 0), 0.543, "angle", SampleSize(64), 45),
             ((1, 1), 0.632, "angle", "64x64", 100),
@@ -34,7 +33,7 @@ class TestZernikeStandardCoefficientsAnalysis:
         optiland_backend,
         optiland_analysis,
     ):
-        optiland_backend.build_model(EyeModel())
+        optiland_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
 
         args = build_args(
             field_coordinate=field_coordinate,

--- a/tests/optiland/test_models.py
+++ b/tests/optiland/test_models.py
@@ -84,6 +84,40 @@ class TestOptilandEye:
         with pytest.raises(ValueError, match="The retina is not located at the image position"):
             optiland_eye.build(optic)
 
+    def test_build_start_from_index(self, optic: Optic, eye_model: EyeModel):
+        optic.add_surface(index=0, comment="Dummy 1")
+        optic.add_surface(index=1, comment="Dummy 1")
+
+        optiland_eye = OptilandEye(eye_model)
+        optiland_eye.build(optic, start_from_index=1)
+
+        assert optic.surface_group.surfaces[2].comment == "cornea front"
+        assert optic.surface_group.get_thickness(2) == eye_model.geometry.cornea_front.thickness
+
+    @pytest.mark.parametrize("n_surfaces,index", [(0, 1), (0, 3), (2, 2), (2, 3)])
+    def test_build_start_from_index_invalid(self, n_surfaces: int, index: int, optic: Optic, eye_model: EyeModel):
+        for i in range(n_surfaces):
+            optic.add_surface(index=i, comment=f"Dummy {i}")
+
+        optiland_eye = OptilandEye(eye_model)
+
+        with pytest.raises(ValueError, match="'start_from_index' can be at most the index of the last surface in the system"):
+            optiland_eye.build(optic, start_from_index=index)
+
+    def test_build_object_distance(self, optic: Optic, eye_model: EyeModel):
+        optiland_eye = OptilandEye(eye_model)
+        optiland_eye.build(optic, object_distance=10)
+
+        assert optic.surface_group.get_thickness(0) == 10
+
+    def test_build_object_distance_nonempty_system(self, optic: Optic, eye_model: EyeModel):
+        optic.add_surface(index=0, comment="Object")
+
+        optiland_eye = OptilandEye(eye_model)
+
+        with pytest.raises(ValueError, match="Cannot set a custom object distance if the optical system is not empty"):
+            optiland_eye.build(optic, object_distance=10)
+
     def test_get_cornea_front_comment(self, optic: Optic, eye_model: EyeModel):
         optiland_eye = OptilandEye(eye_model)
         optiland_eye.build(optic)

--- a/tests/optiland/test_models.py
+++ b/tests/optiland/test_models.py
@@ -101,7 +101,9 @@ class TestOptilandEye:
 
         optiland_eye = OptilandEye(eye_model)
 
-        with pytest.raises(ValueError, match="'start_from_index' can be at most the index of the last surface in the system"):
+        with pytest.raises(
+            ValueError, match="'start_from_index' can be at most the index of the last surface in the system"
+        ):
             optiland_eye.build(optic, start_from_index=index)
 
     def test_build_object_distance(self, optic: Optic, eye_model: EyeModel):

--- a/visisipy/backend.py
+++ b/visisipy/backend.py
@@ -159,7 +159,15 @@ class BaseBackend(ABC):
 
     @classmethod
     @abstractmethod
-    def build_model(cls, model: EyeModel, **kwargs) -> BaseEye: ...
+    def build_model(
+        cls,
+        model: EyeModel,
+        *,
+        start_from_index: int = 0,
+        replace_existing: bool = False,
+        object_distance: float = float("inf"),
+        **kwargs,
+    ) -> BaseEye: ...
 
     @classmethod
     @abstractmethod

--- a/visisipy/models/__init__.py
+++ b/visisipy/models/__init__.py
@@ -40,9 +40,22 @@ class EyeModel:
     materials: EyeMaterials = field(default_factory=NavarroMaterials)
     _built: BaseEye | None = field(default=None, init=False, repr=False)
 
-    def build(self, **kwargs) -> BaseEye:
+    def build(
+        self,
+        *,
+        start_from_index: int = 0,
+        replace_existing: bool = False,
+        object_distance: float = float("inf"),
+        **kwargs,
+    ) -> BaseEye:
         backend = _backend.get_backend()
-        self._built = backend.build_model(self, **kwargs)
+        self._built = backend.build_model(
+            self,
+            start_from_index=start_from_index,
+            replace_existing=replace_existing,
+            object_distance=object_distance,
+            **kwargs,
+        )
 
         return self._built
 
@@ -90,7 +103,14 @@ class BaseEye(ABC):
     def __init__(self, model: EyeModel): ...
 
     @abstractmethod
-    def build(self, *args, **kwargs):
+    def build(
+        self,
+        *args,
+        start_from_index: int = 0,
+        replace_existing: bool = False,
+        object_distance: float = float("inf"),
+        **kwargs,
+    ):
         """Build the eye model in the backend."""
         ...
 

--- a/visisipy/opticstudio/backend.py
+++ b/visisipy/opticstudio/backend.py
@@ -160,7 +160,15 @@ class OpticStudioBackend(BaseBackend):
         cls.update_settings()
 
     @classmethod
-    def build_model(cls, model: EyeModel, *, replace_existing: bool = False, **kwargs) -> OpticStudioEye:
+    def build_model(
+        cls,
+        model: EyeModel,
+        *,
+        start_from_index: int = 0,
+        replace_existing: bool = False,
+        object_distance: float = float("inf"),
+        **kwargs,
+    ) -> OpticStudioEye:
         """
         Builds an optical system based on the provided eye model.
 
@@ -185,7 +193,13 @@ class OpticStudioBackend(BaseBackend):
             cls.new_model()
 
         opticstudio_eye = OpticStudioEye(model)
-        opticstudio_eye.build(cls.oss, replace_existing=replace_existing, **kwargs)
+        opticstudio_eye.build(
+            cls.oss,
+            start_from_index=start_from_index,
+            replace_existing=replace_existing,
+            object_distance=object_distance,
+            **kwargs,
+        )
 
         cls.model = opticstudio_eye
 

--- a/visisipy/opticstudio/models.py
+++ b/visisipy/opticstudio/models.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 from visisipy.models import BaseEye, EyeModel
 from visisipy.opticstudio.surfaces import OpticStudioSurface, make_surface
 
@@ -182,7 +180,8 @@ class OpticStudioEye(BaseOpticStudioEye):
         oss : zospy.zpcore.OpticStudioSystem
             OpticStudioSystem in which the eye model is created.
         start_from_index : int
-            Index of the surface after which the eye model will be built.
+            Index of the surface after which the eye model will be built. Because the pupil will be located at the stop surface,
+            `start_from_index` must be smaller than the index of the stop surface.
         replace_existing : bool
             If `True`, replaces existing surfaces instead of inserting new ones. Defaults to `False`.
         object_distance : float, optional
@@ -194,7 +193,11 @@ class OpticStudioEye(BaseOpticStudioEye):
             If the pupil is not located at the stop position.
             If the retina is not located at the image surface.
         """
-        if object_distance != np.inf:
+        if start_from_index >= oss.LDE.StopSurface:
+            message = "'start_from_index' must be smaller than the index of the stop surface."
+            raise ValueError(message)
+
+        if object_distance != float("inf"):
             oss.LDE.GetSurfaceAt(start_from_index).Thickness = object_distance
 
         self.cornea_front.build(oss, position=start_from_index + 1, replace_existing=replace_existing)

--- a/visisipy/optiland/backend.py
+++ b/visisipy/optiland/backend.py
@@ -80,18 +80,32 @@ class OptilandBackend(BaseBackend):
         cls.update_settings()
 
     @classmethod
-    def build_model(cls, model: EyeModel, *, replace_existing: bool = False, **kwargs) -> OptilandEye:
+    def build_model(
+        cls,
+        model: EyeModel,
+        *,
+        start_from_index: int = 0,
+        replace_existing: bool = False,
+        object_distance: float = float("inf"),
+        **kwargs,
+    ) -> OptilandEye:
         if not replace_existing and cls.model is not None:
             cls.new_model()
 
         optiland_eye = OptilandEye(model)
-        optiland_eye.build(cls.get_optic(), replace_existing=replace_existing, **kwargs)
+        optiland_eye.build(
+            cls.get_optic(),
+            start_from_index=start_from_index,
+            replace_existing=replace_existing,
+            object_distance=object_distance,
+            **kwargs,
+        )
 
         cls.model = optiland_eye
         return optiland_eye
 
     @classmethod
-    def clear_model(cls) -> NotImplemented:
+    def clear_model(cls) -> None:
         cls.model = None
         cls.optic = None
 

--- a/visisipy/optiland/models.py
+++ b/visisipy/optiland/models.py
@@ -93,10 +93,16 @@ class OptilandEye(BaseEye):
             If the retina is not located at the last surface.
         """
         # Create an object surface if it does not exist
+        if optic.surface_group.num_surfaces != 0 and object_distance != float("inf"):
+            raise ValueError("Cannot set a custom object distance if the optical system is not empty.")
+
         if start_from_index == 0 and optic.surface_group.num_surfaces == 0:
             optic.surface_group.add_surface(
                 index=start_from_index, replace_existing=replace_existing, thickness=object_distance
             )
+        elif start_from_index > optic.surface_group.num_surfaces - 1:
+            message = "'start_from_index' can be at most the index of the last surface in the system."
+            raise ValueError(message)
 
         self.cornea_front.build(optic, position=start_from_index + 1, replace_existing=replace_existing)
         self.cornea_back.build(optic, position=start_from_index + 2, replace_existing=replace_existing)

--- a/visisipy/optiland/models.py
+++ b/visisipy/optiland/models.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 from visisipy.models import BaseEye
 from visisipy.optiland.surfaces import OptilandSurface, make_surface
 
@@ -64,10 +62,41 @@ class OptilandEye(BaseEye):
         """Retina surface."""
         return self._retina
 
-    def build(self, optic: Optic, *, start_from_index: int = 0, replace_existing: bool = False) -> None:
+    def build(
+        self,
+        optic: Optic,
+        *,
+        start_from_index: int = 0,
+        replace_existing: bool = False,
+        object_distance: float = float("inf"),
+    ) -> None:
+        """Create the eye in Optiland.
+
+        Create the eye model in the provided optical system `optic`, starting from `start_from_index`.
+        If `replace_existing` is set to `True`, existing surfaces will be overwritten.
+
+        Parameters
+        ----------
+        optic : Optic
+            Optiland Optic in which the eye model is created.
+        start_from_index : int
+            Index of the surface after which the eye model will be built.
+        replace_existing : bool
+            If `True`, replaces existing surfaces instead of inserting new ones. Defaults to `False`.
+        object_distance : float, optional
+            Distance from the object surface (or the surface before the eye model) to the eye model. Defaults to infinity.
+
+        Raises
+        ------
+        AssertionError
+            If the pupil is not located at the stop position.
+            If the retina is not located at the last surface.
+        """
         # Create an object surface if it does not exist
         if start_from_index == 0 and optic.surface_group.num_surfaces == 0:
-            optic.surface_group.add_surface(index=start_from_index, replace_existing=replace_existing, thickness=np.inf)
+            optic.surface_group.add_surface(
+                index=start_from_index, replace_existing=replace_existing, thickness=object_distance
+            )
 
         self.cornea_front.build(optic, position=start_from_index + 1, replace_existing=replace_existing)
         self.cornea_back.build(optic, position=start_from_index + 2, replace_existing=replace_existing)


### PR DESCRIPTION
Add a new `object_distance` parameter to the model build methods that allows to change the distance between the object surface and the first surface of the eye model. This is necessary to be able to use the `object_height` field type, because object height fields are only defined at finite object distances.

This also solves issues with unit tests that set the field type to `object_height`.

Closes #17 