### PR TITLE
Use `versioningit` to set version numbers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "versioningit"]
 build-backend = "hatchling.build"
 
 [project]
@@ -25,7 +25,7 @@ requires-python = ">=3.9, <3.14"
 dynamic = ["version"]
 
 [tool.hatch.version]
-path = "visisipy/__init__.py"
+source = "versioningit"
 
 [tool.hatch.envs.default]
 installer = "uv"
@@ -78,3 +78,5 @@ extend-ignore = [
 
 [tool.ruff.lint.flake8-pytest-style]
 parametrize-names-type = "csv"
+
+[tool.versioningit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dynamic = ["version"]
 
 [tool.hatch.version]
 source = "versioningit"
+default-version = "0.0.0+unknown"
 
 [tool.hatch.envs.default]
 installer = "uv"
@@ -78,5 +79,3 @@ extend-ignore = [
 
 [tool.ruff.lint.flake8-pytest-style]
 parametrize-names-type = "csv"
-
-[tool.versioningit]

--- a/visisipy/__init__.py
+++ b/visisipy/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from importlib.metadata import version
+
 from visisipy import analysis, models, opticstudio, optiland, plots, refraction, wavefront
 from visisipy.backend import get_backend, set_backend, update_settings
 from visisipy.models import (
@@ -27,3 +29,5 @@ __all__ = (
     "update_settings",
     "wavefront",
 )
+
+__version__ = version("visisipy")

--- a/visisipy/__init__.py
+++ b/visisipy/__init__.py
@@ -27,5 +27,3 @@ __all__ = (
     "update_settings",
     "wavefront",
 )
-
-__version__ = "0.0.1"


### PR DESCRIPTION
Use `versioningit` to obtain version numbers from `git`.
For releases, the release tag will be used.
For other commits, the version will be based on the latest tag and the commit hash.