### PR TITLE
Add support for non-Windows systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
   test:
     name: "Test"
     runs-on: windows-latest
-    strategy: &test-strategy
+    strategy:
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
-    steps: &test-steps
+    steps:
       - uses: actions/checkout@v4
       - name: Set up uv
         id: setup-uv
@@ -34,6 +34,14 @@ jobs:
   test-linux:
     name: "Test Linux"
     runs-on: ubuntu-latest
-    strategy: *test-strategy
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
-    steps: *test-steps
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@v3
+      - name: Run tests
+        run: uvx hatch test --python ${{ matrix.python-version }} ./tests --no-opticstudio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,21 @@ jobs:
   test:
     name: "Test"
     runs-on: windows-latest
-    strategy:
+    strategy: &test-strategy
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
-    steps:
+    steps: &test-steps
       - uses: actions/checkout@v4
       - name: Set up uv
         id: setup-uv
         uses: astral-sh/setup-uv@v3
       - name: Run tests
         run: uvx hatch test --python ${{ matrix.python-version }} ./tests --no-opticstudio
+
+  test-linux:
+    name: "Test Linux"
+    runs-on: ubuntu-latest
+    strategy: *test-strategy
+
+    steps: *test-steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,13 @@ maintainers = [
     { name = "MReye research group", email = "zospy@mreye.nl" }
 ]
 dependencies = [
-    "zospy>=2.0.2",
     "matplotlib",
     "numba>=0.60.0", # Required for Optiland. Maximum version still supporting Python 3.9.
     "numpy",
     "optiland>=0.3.1",
     "scipy",
     "typing-extensions>=4.12.2 ; python_full_version < '3.11'",
+    "zospy>=2.0.2; sys_platform == 'win32'",
 ]
 requires-python = ">=3.9, <3.14"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 [tool.pytest.ini_options]
 markers = [
     "needs_opticstudio: test needs OpticStudio and will be skipped if it is not available",
+    "windows_only: test can only be run on Windows",
 ]
 filterwarnings = [
     "ignore:Header and row length mismatch",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import platform
 from typing import Literal
 
 import pytest
@@ -5,6 +6,10 @@ import pytest
 from visisipy import EyeGeometry, EyeMaterials, EyeModel
 from visisipy.models.geometry import StandardSurface, Stop
 from visisipy.models.materials import MaterialModel
+
+# Only run the OpticStudio tests on Windows
+if platform.system() != "Windows":
+    collect_ignore = ["opticstudio"]
 
 
 def pytest_addoption(parser):
@@ -35,6 +40,9 @@ def pytest_collection_modifyitems(config, items):
 
 
 def detect_opticstudio() -> bool:
+    if platform.system() != "Windows":
+        return False
+
     import zospy as zp  # noqa: PLC0415
 
     opticstudio_available: bool = False
@@ -72,6 +80,12 @@ def opticstudio_available(request) -> bool:
 def skip_opticstudio(request, opticstudio_available):
     if request.node.get_closest_marker("needs_opticstudio") and not opticstudio_available:
         pytest.skip("OpticStudio is not available.")
+
+
+@pytest.fixture(autouse=True)
+def skip_windows_only(request, opticstudio_available):
+    if request.node.get_closest_marker("windows_only") and platform.system() != "Windows":
+        pytest.skip("Running on a non-Windows platform.")
 
 
 @pytest.fixture

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,12 +1,17 @@
+import platform
 from typing import Any
 
 import pytest
 
-import visisipy.opticstudio
 import visisipy.optiland
 from visisipy import backend
-from visisipy.opticstudio.backend import OpticStudioBackend
 from visisipy.optiland.backend import OptilandBackend
+
+if platform.system() == "Windows":
+    import visisipy.opticstudio
+    from visisipy.opticstudio.backend import OpticStudioBackend
+else:
+    OpticStudioBackend = object()
 
 # ruff: noqa: SLF001
 # pyright: reportOptionalMemberAccess=false, reportTypedDictNotRequiredAccess=false
@@ -59,6 +64,7 @@ def mock_optiland_backend(monkeypatch):
 
 
 class TestSetBackend:
+    @pytest.mark.windows_only
     @pytest.mark.parametrize("name", ["opticstudio", backend.Backend.OPTICSTUDIO])
     def test_set_opticstudio_backend(self, name, mock_opticstudio_backend, monkeypatch):
         monkeypatch.setattr(backend, "_BACKEND", None)  # Reset the backend to avoid side effects in other tests
@@ -91,6 +97,7 @@ class TestSetBackend:
 
 
 class TestGetBackend:
+    @pytest.mark.windows_only
     def test_get_backend(self, mock_opticstudio_backend, monkeypatch):
         monkeypatch.setattr(backend, "_BACKEND", mock_opticstudio_backend)
 
@@ -106,11 +113,13 @@ class TestGetBackend:
 
 
 class TestGetModels:
+    @pytest.mark.windows_only
     def test_get_oss(self, mock_opticstudio_backend, monkeypatch):
         monkeypatch.setattr(backend, "_BACKEND", mock_opticstudio_backend)
 
         assert backend.get_oss() is mock_opticstudio_backend.oss
 
+    @pytest.mark.windows_only
     def test_get_oss_no_opticstudio_backend(self, mock_optiland_backend):
         assert backend.get_oss() is None
 
@@ -119,7 +128,7 @@ class TestGetModels:
 
         assert backend.get_optic() is mock_optiland_backend.optic
 
-    def test_get_optic_no_optiland_backend(self, mock_opticstudio_backend):
+    def test_get_optic_no_optiland_backend(self, mock_backend):
         assert backend.get_optic() is None
 
 
@@ -136,7 +145,9 @@ class TestUpdateSettings:
         assert backend._BACKEND.settings["wavelengths"] == [550]
 
     @pytest.mark.filterwarnings("ignore:The OpticStudio backend settings")
-    @pytest.mark.parametrize("backend_type", [OpticStudioBackend, OptilandBackend])
+    @pytest.mark.parametrize(
+        "backend_type", [pytest.param(OpticStudioBackend, marks=pytest.mark.windows_only), OptilandBackend]
+    )
     def test_update_settings_by_backend(self, backend_type):
         field_type = "object_height"
         fields = [(0, 0), (1, 1)]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,35 @@
+import platform
+from types import ModuleType
+
+import pytest
+
+# ruff: noqa: PLC0415
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="ZOSPy is only available on Windows")
+class TestZospyImportWindows:
+    def test_zospy_import(self):
+        import zospy as zp
+
+        assert isinstance(zp, ModuleType)
+
+    def test_opticstudio_in_all(self):
+        import visisipy
+
+        assert "opticstudio" in visisipy.__all__
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="No ImportError raised on Windows")
+class TestZospyImportNonWindows:
+    @pytest.mark.parametrize(
+        "import_statement",
+        ["import zospy", "import zospy as zp", "from zospy import analyses", "import zospy.constants as constants"],
+    )
+    def test_zospy_import_raises_importerror(self, import_statement):
+        with pytest.raises(ImportError, match="ZOSPy is only available on Windows"):
+            eval(import_statement)
+
+    def test_opticstudio_not_in_all(self):
+        import visisipy
+
+        assert "opticstudio" not in visisipy.__all__

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -6,7 +6,7 @@ import pytest
 # ruff: noqa: PLC0415
 
 
-@pytest.mark.skipif(platform.system() != "Windows", reason="ZOSPy is only available on Windows")
+@pytest.mark.windows_only
 class TestZospyImportWindows:
     def test_zospy_import(self):
         import zospy as zp
@@ -26,8 +26,8 @@ class TestZospyImportNonWindows:
         ["import zospy", "import zospy as zp", "from zospy import analyses", "import zospy.constants as constants"],
     )
     def test_zospy_import_raises_importerror(self, import_statement):
-        with pytest.raises(ImportError, match="ZOSPy is only available on Windows"):
-            eval(import_statement)
+        with pytest.raises(ImportError, match="Could not import module 'zospy'"):
+            exec(import_statement)
 
     def test_opticstudio_not_in_all(self):
         import visisipy

--- a/visisipy/__init__.py
+++ b/visisipy/__init__.py
@@ -23,7 +23,6 @@ __all__ = [
     "analysis",
     "get_backend",
     "models",
-    "opticstudio",
     "optiland",
     "plots",
     "refraction",

--- a/visisipy/__init__.py
+++ b/visisipy/__init__.py
@@ -39,3 +39,5 @@ if platform.system() == "Windows":
     __all__ += ["opticstudio"]
 
 __version__ = version("visisipy")
+
+install_zospy_loader()

--- a/visisipy/__init__.py
+++ b/visisipy/__init__.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import platform
 from importlib.metadata import version
 
-from visisipy import analysis, models, opticstudio, optiland, plots, refraction, wavefront
+from visisipy import analysis, models, optiland, plots, refraction, wavefront
+from visisipy._zospy_loader import install_zospy_loader
 from visisipy.backend import get_backend, set_backend, update_settings
 from visisipy.models import (
     EyeGeometry,
@@ -12,7 +14,7 @@ from visisipy.models import (
     NavarroMaterials,
 )
 
-__all__ = (
+__all__ = [
     "EyeGeometry",
     "EyeMaterials",
     "EyeModel",
@@ -28,6 +30,12 @@ __all__ = (
     "set_backend",
     "update_settings",
     "wavefront",
-)
+]
+
+# The OpticStudio backend is only available on Windows
+if platform.system() == "Windows":
+    from visisipy import opticstudio
+
+    __all__ += ["opticstudio"]
 
 __version__ = version("visisipy")

--- a/visisipy/_zospy_loader.py
+++ b/visisipy/_zospy_loader.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib
+import platform
+import sys
+from importlib.machinery import ModuleSpec
+
+__all__ = ("install_zospy_loader",)
+
+
+class ZOSPyLoader:
+    def __init__(self, name):
+        self.name = name
+
+    @staticmethod
+    def load_module(fullname):
+        if platform.system() != "Windows":
+            message = (
+                f"Could not import module '{fullname}'.\n"
+                "Visisipy's OpticStudio backend depends on ZOSPy, which is not available on non-Windows systems. "
+                "To use the OpticStudio backend, use Visisipy on a Windows system."
+            )
+            raise ImportError(message)
+
+        # If on Windows, attempt to import the actual module
+        return importlib.import_module(fullname)
+
+
+class ZOSPyFinder:
+    @staticmethod
+    def find_spec(fullname, path, target=None) -> ModuleSpec | None:  # noqa: ARG004
+        if fullname.startswith("zospy"):
+            return ModuleSpec(name=fullname, loader=ZOSPyLoader(fullname))
+
+        return None
+
+
+def install_zospy_loader():
+    """Install the ZOSPy loader to handle the import of the ZOSPy module."""
+    if "zospy" not in sys.modules:
+        sys.meta_path.insert(0, ZOSPyFinder())


### PR DESCRIPTION
With the addition of an Optiland backend, Visisipy can also run on systems other than Linux, but the import of ZOSPy in various parts of Visisipy caused immediate exceptions when trying to import Visisipy on platforms without a dotnet runtime. This is addressed with the following changes:

1. Only import the `opticstudio` submodule when running on Windows;
2. Added a custom finder and loader to intercept ZOSPy imports and raise an exception explaining that Visisipy's OpticStudio backend only supports Windows;
3. Modified the dependencies so that ZOSPy is only installed on Windows systems;
4. Added tests for changes 1 and 2;
5. Skip OpticStudio-specific tests on non-Windows systems and completely exclude the `tests.opticstudio` submodule from test collection;
6. Extend the CI configuration to also run the tests on Linux.