### PR TITLE
Require `from __future__ import annotation` everywhere in `visisipy/` and `tests/`

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,4 +1,6 @@
 # %%
+from __future__ import annotations
+
 from operator import itemgetter
 from typing import NamedTuple
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,8 @@ extend-ignore = [
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]
-"docs/*" = ["INP001", "T20"]
-"examples/*" = ["INP001", "T20"]
+"docs/*" = ["I002", "INP001", "T20"]
+"examples/*" = ["I002", "INP001", "T20"]
 "scripts/*" = ["S101"]
 "tests/*" = ["ARG001", "ARG002", "FBT001", "PLC2701"]
 "tests/opticstudio/*" = ["SLF001"]
@@ -108,6 +108,10 @@ extend-ignore = [
 
 [tool.ruff.lint.flake8-pytest-style]
 parametrize-names-type = "csv"
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
+
 
 [tool.pydocstringformatter]
 style = "numpydoc"

--- a/scripts/material_models/.ruff.toml
+++ b/scripts/material_models/.ruff.toml
@@ -1,1 +1,2 @@
+extend = "../../pyproject.toml"
 target-version = "py311"

--- a/tests/analysis/test_analyses.py
+++ b/tests/analysis/test_analyses.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import visisipy
 import visisipy.backend
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 from typing import Literal
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/models/test_materials.py
+++ b/tests/models/test_materials.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from visisipy.models.materials import EyeMaterials, MaterialModel, NavarroMaterials
 
 

--- a/tests/opticstudio/analysis/conftest.py
+++ b/tests/opticstudio/analysis/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/opticstudio/analysis/test_cardinal_points.py
+++ b/tests/opticstudio/analysis/test_cardinal_points.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import nullcontext as does_not_raise
 
 import pytest

--- a/tests/opticstudio/analysis/test_raytrace.py
+++ b/tests/opticstudio/analysis/test_raytrace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import nullcontext as does_not_raise
 
 import pytest

--- a/tests/opticstudio/analysis/test_refraction.py
+++ b/tests/opticstudio/analysis/test_refraction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 import pytest

--- a/tests/opticstudio/analysis/test_zernike_coefficients.py
+++ b/tests/opticstudio/analysis/test_zernike_coefficients.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from tests.helpers import build_args

--- a/tests/opticstudio/test_backend.py
+++ b/tests/opticstudio/test_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from contextlib import nullcontext as does_not_raise
 from typing import TYPE_CHECKING

--- a/tests/opticstudio/test_material_models.py
+++ b/tests/opticstudio/test_material_models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import zospy as zp

--- a/tests/opticstudio/test_surfaces.py
+++ b/tests/opticstudio/test_surfaces.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from contextlib import nullcontext as does_not_raise
 from types import SimpleNamespace

--- a/tests/optiland/analysis/conftest.py
+++ b/tests/optiland/analysis/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/optiland/analysis/test_cardinal_points.py
+++ b/tests/optiland/analysis/test_cardinal_points.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import nullcontext as does_not_raise
 
 import pytest

--- a/tests/optiland/analysis/test_raytrace.py
+++ b/tests/optiland/analysis/test_raytrace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import nullcontext as does_not_raise
 
 import pytest

--- a/tests/optiland/analysis/test_refraction.py
+++ b/tests/optiland/analysis/test_refraction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from types import MethodType, SimpleNamespace
 

--- a/tests/optiland/analysis/test_zernike_coefficients.py
+++ b/tests/optiland/analysis/test_zernike_coefficients.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from tests.helpers import build_args

--- a/tests/optiland/test_material_models.py
+++ b/tests/optiland/test_material_models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from optiland.materials import AbbeMaterial, IdealMaterial

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 from typing import Any
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 from types import ModuleType
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import nullcontext as does_not_raise
 
 import pytest

--- a/tests/test_wavefront.py
+++ b/tests/test_wavefront.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import nullcontext as does_not_raise
 
 import pytest

--- a/visisipy/opticstudio/analysis/__init__.py
+++ b/visisipy/opticstudio/analysis/__init__.py
@@ -1,5 +1,7 @@
 """Implementation of Visisipy's analyses for the OpticStudio backend."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from visisipy.backend import BaseAnalysisRegistry, _AnalysisMethod
@@ -19,7 +21,7 @@ __all__ = ("OpticStudioAnalysisRegistry",)
 class OpticStudioAnalysisRegistry(BaseAnalysisRegistry):
     """Analyses for the OpticStudio backend."""
 
-    def __init__(self, backend: "OpticStudioBackend"):
+    def __init__(self, backend: OpticStudioBackend):
         super().__init__(backend)
         self._oss = backend.oss
 

--- a/visisipy/optiland/analysis/__init__.py
+++ b/visisipy/optiland/analysis/__init__.py
@@ -1,5 +1,7 @@
 """Analyze optical eye models in Optiland."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from visisipy.backend import BaseAnalysisRegistry, _AnalysisMethod
@@ -17,7 +19,7 @@ __all__ = ("OptilandAnalysisRegistry",)
 class OptilandAnalysisRegistry(BaseAnalysisRegistry):
     """Analyses for the OpticStudio backend."""
 
-    def __init__(self, backend: "OptilandBackend"):
+    def __init__(self, backend: OptilandBackend):
         super().__init__(backend)
         self._optic = backend.optic
 


### PR DESCRIPTION
Configured `ruff` to require `from __future__ import annotation` throughout the code base and add it where missing. This import is not required in examples and documentation.
It is also not strictly necessary in `example.py`, but as I plan to remove that file in the near future, I didn't add an exception for this file.