### PR TITLE
Let `Surface.build` return the index of the surface

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Literal
 import pytest
 
 from visisipy import EyeGeometry, EyeMaterials, EyeModel
-from visisipy.models.geometry import StandardSurface, Stop
+from visisipy.models.geometry import NoSurface, StandardSurface, Stop
 from visisipy.models.materials import MaterialModel
 
 # Only run the OpticStudio tests on Windows
@@ -107,3 +107,21 @@ def eye_model():
     )
 
     return EyeModel(geometry=geometry, materials=materials)
+
+
+@pytest.fixture
+def three_surface_eye_model():
+    """Eye model with three optical surfaces.
+
+    The cornea back surface is omitted using a `NoSurface` object.
+    """
+    geometry = EyeGeometry(
+        cornea_front=StandardSurface(radius=7.72, asphericity=-0.26, thickness=0.55),
+        cornea_back=NoSurface(),
+        pupil=Stop(semi_diameter=1.348),
+        lens_front=StandardSurface(radius=10.2, asphericity=-3.1316, thickness=4.0),
+        lens_back=StandardSurface(radius=-6.0, asphericity=-1, thickness=16.3203),
+        retina=StandardSurface(radius=-12.0, asphericity=0),
+    )
+
+    return EyeModel(geometry)

--- a/tests/opticstudio/test_models.py
+++ b/tests/opticstudio/test_models.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-from visisipy import EyeGeometry
-from visisipy.models import EyeModel
-from visisipy.models.geometry import NoSurface, StandardSurface, Stop
 from visisipy.opticstudio import OpticStudioEye
 
 # pyright: reportOptionalMemberAccess=false
@@ -230,17 +227,8 @@ class TestOpticStudioEye:
         assert opticstudio_eye.retina.comment == "retina"
 
 
-def test_model_with_no_surface(oss):
-    geometry = EyeGeometry(
-        cornea_front=StandardSurface(radius=7.72, asphericity=-0.26, thickness=0.55),
-        cornea_back=NoSurface(),
-        pupil=Stop(semi_diameter=1.348),
-        lens_front=StandardSurface(radius=10.2, asphericity=-3.1316, thickness=4.0),
-        lens_back=StandardSurface(radius=-6.0, asphericity=-1, thickness=16.3203),
-        retina=StandardSurface(radius=-12.0, asphericity=0),
-    )
-    eye_model = EyeModel(geometry)
-    opticstudio_eye = OpticStudioEye(eye_model)
+def test_model_with_no_surface(oss, three_surface_eye_model):
+    opticstudio_eye = OpticStudioEye(three_surface_eye_model)
     opticstudio_eye.build(oss)
 
     assert oss.LDE.NumberOfSurfaces == 6

--- a/tests/opticstudio/test_models.py
+++ b/tests/opticstudio/test_models.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import pytest
 
+from visisipy import EyeGeometry
+from visisipy.models import EyeModel
+from visisipy.models.geometry import NoSurface, StandardSurface, Stop
 from visisipy.opticstudio import OpticStudioEye
 
 # pyright: reportOptionalMemberAccess=false
@@ -225,3 +228,25 @@ class TestOpticStudioEye:
         assert opticstudio_eye.lens_back.comment == "lens back / vitreous"
         assert opticstudio_eye.retina.surface.SurfaceNumber == 7
         assert opticstudio_eye.retina.comment == "retina"
+
+
+def test_model_with_no_surface(oss):
+    geometry = EyeGeometry(
+        cornea_front=StandardSurface(radius=7.72, asphericity=-0.26, thickness=0.55),
+        cornea_back=NoSurface(),
+        pupil=Stop(semi_diameter=1.348),
+        lens_front=StandardSurface(radius=10.2, asphericity=-3.1316, thickness=4.0),
+        lens_back=StandardSurface(radius=-6.0, asphericity=-1, thickness=16.3203),
+        retina=StandardSurface(radius=-12.0, asphericity=0),
+    )
+    eye_model = EyeModel(geometry)
+    opticstudio_eye = OpticStudioEye(eye_model)
+    opticstudio_eye.build(oss)
+
+    assert oss.LDE.NumberOfSurfaces == 6
+    assert opticstudio_eye.cornea_front.surface.SurfaceNumber == 1
+    assert opticstudio_eye.pupil.surface.SurfaceNumber == 2
+    assert opticstudio_eye.lens_front.surface.SurfaceNumber == 3
+    assert opticstudio_eye.lens_back.surface.SurfaceNumber == 4
+    assert opticstudio_eye.retina.surface.SurfaceNumber == 5
+    assert opticstudio_eye.cornea_back.surface is None

--- a/tests/opticstudio/test_surfaces.py
+++ b/tests/opticstudio/test_surfaces.py
@@ -7,6 +7,7 @@ import pytest
 from zospy.solvers import material_model as solve_material_model
 
 from visisipy.models.geometry import (
+    NoSurface,
     StandardSurface,
     Stop,
     Surface,
@@ -14,15 +15,10 @@ from visisipy.models.geometry import (
     ZernikeStandardSagSurface,
 )
 from visisipy.models.materials import MaterialModel
-from visisipy.opticstudio.surfaces import (
-    BaseOpticStudioZernikeSurface,
-    OpticStudioSurface,
-    OpticStudioSurfaceDataProperty,
-    OpticStudioSurfaceProperty,
-    OpticStudioZernikeStandardPhaseSurface,
-    OpticStudioZernikeStandardSagSurface,
-    make_surface,
-)
+from visisipy.opticstudio.surfaces import (BaseOpticStudioZernikeSurface, OpticStudioNoSurface, OpticStudioSurface,
+                                           OpticStudioSurfaceDataProperty, OpticStudioSurfaceProperty,
+                                           OpticStudioZernikeStandardPhaseSurface, OpticStudioZernikeStandardSagSurface,
+                                           make_surface)
 from visisipy.wavefront import ZernikeCoefficients
 
 pytestmark = [pytest.mark.needs_opticstudio]
@@ -479,6 +475,19 @@ class TestOpticStudioZernikeStandardPhaseSurface:
         assert surface.surface.SurfaceData.Extrapolate == extrapolate
 
 
+class TestNoSurface:
+    def test_build(self, oss):
+        surface = OpticStudioNoSurface()
+
+        n_surfaces = oss.LDE.NumberOfSurfaces
+
+        return_index = surface.build(oss, position=1)
+
+        assert return_index == 0
+        assert surface.surface is None
+        assert n_surfaces == oss.LDE.NumberOfSurfaces
+
+
 class TestMakeSurface:
     def test_make_surface(self):
         surface = Surface(thickness=1)
@@ -591,3 +600,9 @@ class TestMakeSurface:
         assert opticstudio_surface._extrapolate == 1
         assert opticstudio_surface._zernike_coefficients == {1: 1.0, 2: 2.0, 3: 3.0}
         assert opticstudio_surface._material == "BK7"
+
+    def test_make_no_surface(self):
+        surface = NoSurface()
+        opticstudio_surface = make_surface(surface)
+
+        assert isinstance(opticstudio_surface, OpticStudioNoSurface)

--- a/tests/opticstudio/test_surfaces.py
+++ b/tests/opticstudio/test_surfaces.py
@@ -143,7 +143,9 @@ class TestOpticStudioSurface:
         )
 
         assert surface._is_built is False
-        surface.build(oss, position=2)
+        surface_index = surface.build(oss, position=2)
+
+        assert surface_index == 2
         assert surface._is_built is True
 
         assert surface.surface.SurfaceNumber == 2
@@ -247,6 +249,11 @@ class TestOpticStudioSurface:
         surface.build(oss, position=1)
 
         assert surface.surface.TypeName == "ABCD"
+
+    def test_build_returns_index(self, oss):
+        surface = OpticStudioSurface(comment="Test")
+
+        assert surface.build(oss, position=1) == 1
 
 
 class TestBaseOpticStudioZernikeSurface:
@@ -355,7 +362,9 @@ class TestOpticStudioZernikeStandardSagSurface:
         )
 
         assert surface._is_built is False
-        surface.build(oss, position=1)
+        surface_index = surface.build(oss, position=1)
+
+        assert surface_index == 1
         assert surface._is_built is True
         assert str(surface.surface.Type) == "ZernikeStandardSag"
 
@@ -429,7 +438,9 @@ class TestOpticStudioZernikeStandardPhaseSurface:
         )
 
         assert surface._is_built is False
-        surface.build(oss, position=1)
+        surface_index = surface.build(oss, position=1)
+
+        assert surface_index == 1
         assert surface._is_built is True
         assert str(surface.surface.Type) == "ZernikeStandardPhase"
 

--- a/tests/opticstudio/test_surfaces.py
+++ b/tests/opticstudio/test_surfaces.py
@@ -15,10 +15,16 @@ from visisipy.models.geometry import (
     ZernikeStandardSagSurface,
 )
 from visisipy.models.materials import MaterialModel
-from visisipy.opticstudio.surfaces import (BaseOpticStudioZernikeSurface, OpticStudioNoSurface, OpticStudioSurface,
-                                           OpticStudioSurfaceDataProperty, OpticStudioSurfaceProperty,
-                                           OpticStudioZernikeStandardPhaseSurface, OpticStudioZernikeStandardSagSurface,
-                                           make_surface)
+from visisipy.opticstudio.surfaces import (
+    BaseOpticStudioZernikeSurface,
+    OpticStudioNoSurface,
+    OpticStudioSurface,
+    OpticStudioSurfaceDataProperty,
+    OpticStudioSurfaceProperty,
+    OpticStudioZernikeStandardPhaseSurface,
+    OpticStudioZernikeStandardSagSurface,
+    make_surface,
+)
 from visisipy.wavefront import ZernikeCoefficients
 
 pytestmark = [pytest.mark.needs_opticstudio]

--- a/tests/optiland/test_models.py
+++ b/tests/optiland/test_models.py
@@ -4,12 +4,13 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from visisipy import EyeGeometry, EyeModel
+from visisipy.models.geometry import NoSurface, StandardSurface, Stop
 from visisipy.optiland import OptilandEye
 
 if TYPE_CHECKING:
     from optiland.optic import Optic
 
-    from visisipy import EyeModel
 
 
 class TestOptilandEye:
@@ -197,3 +198,25 @@ class TestOptilandEye:
         assert optiland_eye.lens_front.comment != "new comment"
         assert optiland_eye.lens_back.comment == "new comment"
         assert optiland_eye.retina.comment != "new comment"
+
+
+def test_model_with_no_surface(optic):
+    geometry = EyeGeometry(
+        cornea_front=StandardSurface(radius=7.72, asphericity=-0.26, thickness=0.55),
+        cornea_back=NoSurface(),
+        pupil=Stop(semi_diameter=1.348),
+        lens_front=StandardSurface(radius=10.2, asphericity=-3.1316, thickness=4.0),
+        lens_back=StandardSurface(radius=-6.0, asphericity=-1, thickness=16.3203),
+        retina=StandardSurface(radius=-12.0, asphericity=0),
+    )
+    eye_model = EyeModel(geometry)
+    optiland_eye = OptilandEye(eye_model)
+    optiland_eye.build(optic)
+
+    assert optic.surface_group.num_surfaces == 6
+    assert optiland_eye.cornea_front.surface == optic.surface_group.surfaces[1]
+    assert optiland_eye.pupil.surface == optic.surface_group.surfaces[2]
+    assert optiland_eye.lens_front.surface == optic.surface_group.surfaces[3]
+    assert optiland_eye.lens_back.surface == optic.surface_group.surfaces[4]
+    assert optiland_eye.retina.surface == optic.surface_group.surfaces[5]
+    assert optiland_eye.cornea_back.surface is None

--- a/tests/optiland/test_models.py
+++ b/tests/optiland/test_models.py
@@ -4,12 +4,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from visisipy import EyeGeometry, EyeModel
-from visisipy.models.geometry import NoSurface, StandardSurface, Stop
 from visisipy.optiland import OptilandEye
 
 if TYPE_CHECKING:
     from optiland.optic import Optic
+
+    from visisipy import EyeModel
 
 
 class TestOptilandEye:
@@ -199,17 +199,8 @@ class TestOptilandEye:
         assert optiland_eye.retina.comment != "new comment"
 
 
-def test_model_with_no_surface(optic):
-    geometry = EyeGeometry(
-        cornea_front=StandardSurface(radius=7.72, asphericity=-0.26, thickness=0.55),
-        cornea_back=NoSurface(),
-        pupil=Stop(semi_diameter=1.348),
-        lens_front=StandardSurface(radius=10.2, asphericity=-3.1316, thickness=4.0),
-        lens_back=StandardSurface(radius=-6.0, asphericity=-1, thickness=16.3203),
-        retina=StandardSurface(radius=-12.0, asphericity=0),
-    )
-    eye_model = EyeModel(geometry)
-    optiland_eye = OptilandEye(eye_model)
+def test_model_with_no_surface(optic, three_surface_eye_model):
+    optiland_eye = OptilandEye(three_surface_eye_model)
     optiland_eye.build(optic)
 
     assert optic.surface_group.num_surfaces == 6

--- a/tests/optiland/test_models.py
+++ b/tests/optiland/test_models.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from optiland.optic import Optic
 
 
-
 class TestOptilandEye:
     def test_init(self, eye_model):
         opticstudio_eye = OptilandEye(eye_model)

--- a/tests/optiland/test_surfaces.py
+++ b/tests/optiland/test_surfaces.py
@@ -6,10 +6,11 @@ from typing import TYPE_CHECKING
 import optiland.materials
 import pytest
 
-from visisipy.models.geometry import StandardSurface, Stop, Surface
+from visisipy.models.geometry import NoSurface, StandardSurface, Stop, Surface
 from visisipy.models.materials import MaterialModel
 from visisipy.optiland.surfaces import (
     OptilandSurface,
+    OptilandNoSurface,
     _built_only_property,
     make_surface,
 )
@@ -229,6 +230,19 @@ class TestOptilandSurface:
             build_surface(optic, surface)
 
 
+class TestNoSurface:
+    def test_build(self, optic):
+        surface = OptilandNoSurface()
+
+        n_surfaces = optic.surface_group.num_surfaces
+
+        return_index = surface.build(optic, position=1)
+
+        assert return_index == 0
+        assert surface.surface is None
+        assert n_surfaces == optic.surface_group.num_surfaces
+
+
 class TestMakeSurface:
     def test_make_surface(self):
         surface = Surface(thickness=1)
@@ -287,3 +301,9 @@ class TestMakeSurface:
         assert optiland_surface._semi_diameter == semi_diameter
         assert optiland_surface._material == material
         assert optiland_surface._is_stop is True
+
+    def test_make_no_surface(self):
+        surface = NoSurface()
+        opticstudio_surface = make_surface(surface)
+
+        assert isinstance(opticstudio_surface, OptilandNoSurface)

--- a/tests/optiland/test_surfaces.py
+++ b/tests/optiland/test_surfaces.py
@@ -9,8 +9,8 @@ import pytest
 from visisipy.models.geometry import NoSurface, StandardSurface, Stop, Surface
 from visisipy.models.materials import MaterialModel
 from visisipy.optiland.surfaces import (
-    OptilandSurface,
     OptilandNoSurface,
+    OptilandSurface,
     _built_only_property,
     make_surface,
 )

--- a/tests/optiland/test_surfaces.py
+++ b/tests/optiland/test_surfaces.py
@@ -108,7 +108,7 @@ class TestBuiltOnlyProperty:
             mock_surface.comment = "New comment"
 
 
-def build_surface(optic: Optic, surface: OptilandSurface) -> None:
+def build_surface(optic: Optic, surface: OptilandSurface) -> int:
     """Build a surface with `surface_settings` to the optic system, between an object and image surface."""
     optic.add_surface(
         index=0,
@@ -116,7 +116,7 @@ def build_surface(optic: Optic, surface: OptilandSurface) -> None:
         comment="Object",
     )
 
-    surface.build(optic, position=1)
+    index = surface.build(optic, position=1)
 
     optic.add_surface(
         index=2,
@@ -125,6 +125,8 @@ def build_surface(optic: Optic, surface: OptilandSurface) -> None:
         conic=0.0,
         comment="Image",
     )
+
+    return index
 
 
 class TestOptilandSurface:
@@ -145,8 +147,10 @@ class TestOptilandSurface:
         assert surface._optic is None
         assert surface._index is None
 
-        build_surface(optic, surface)
+        surface_index = build_surface(optic, surface)
 
+        assert surface_index == 1
+        assert surface.surface is not None
         assert surface._is_built is True
         assert surface._optic == optic
         assert surface._index == 1
@@ -171,8 +175,9 @@ class TestOptilandSurface:
             is_stop=True,
         )
 
-        build_surface(optic, surface)
+        surface_index = build_surface(optic, surface)
 
+        assert surface_index == 1
         assert surface.material == material
         assert isinstance(surface.surface.material_post, optiland.materials.IdealMaterial)
         assert surface.surface.material_post.index == material.refractive_index
@@ -190,8 +195,9 @@ class TestOptilandSurface:
             is_stop=True,
         )
 
-        build_surface(optic, surface)
+        surface_index = build_surface(optic, surface)
 
+        assert surface_index == 1
         assert surface.material == material
         assert isinstance(surface.surface.material_post, optiland.materials.AbbeMaterial)
         assert surface.surface.material_post.index == material.refractive_index
@@ -209,8 +215,9 @@ class TestOptilandSurface:
             is_stop=True,
         )
 
-        build_surface(optic, surface)
+        surface_index = build_surface(optic, surface)
 
+        assert surface_index == 1
         assert surface.material == material
         assert isinstance(surface.surface.material_post, optiland.materials.Material)
         assert surface.surface.material_post.name == material

--- a/visisipy/models/__init__.py
+++ b/visisipy/models/__init__.py
@@ -160,7 +160,7 @@ class NoSurface(BaseSurface):
     """Dummy surface class for when no surface is needed."""
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        pass
 
     @property
     def surface(self) -> None:

--- a/visisipy/models/__init__.py
+++ b/visisipy/models/__init__.py
@@ -151,9 +151,23 @@ class BaseSurface(ABC):
     def surface(self) -> Any: ...
 
     @abstractmethod
-    def build(self, *args, **kwargs) -> int:
+    def build(self, *args, position: int, replace_existing: bool = False) -> int:
         """Build the surface in the backend."""
         ...
+
+
+class NoSurface(BaseSurface):
+    """Dummy surface class for when no surface is needed."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def surface(self) -> None:
+        return None
+
+    def build(self, *args, position: int, **kwargs) -> int:  # noqa: ARG002, PLR6301
+        return position - 1
 
 
 class BaseEye(ABC):

--- a/visisipy/models/__init__.py
+++ b/visisipy/models/__init__.py
@@ -151,7 +151,7 @@ class BaseSurface(ABC):
     def surface(self) -> Any: ...
 
     @abstractmethod
-    def build(self, *args, **kwargs):
+    def build(self, *args, **kwargs) -> int:
         """Build the surface in the backend."""
         ...
 

--- a/visisipy/models/__init__.py
+++ b/visisipy/models/__init__.py
@@ -157,7 +157,10 @@ class BaseSurface(ABC):
 
 
 class NoSurface(BaseSurface):
-    """Dummy surface class for when no surface is needed."""
+    """Dummy surface class for when no surface is needed.
+
+    This is a generic implementation that works with all backends, because it does not modify the optical system.
+    """
 
     def __init__(self, *args, **kwargs):
         pass

--- a/visisipy/models/geometry.py
+++ b/visisipy/models/geometry.py
@@ -214,8 +214,15 @@ class NoSurface(Surface):
     """A surface that does not exist.
 
     This surface is used to indicate that a surface is not present in the optical system.
+    It can be used to define three-surface schematic eyes and reduced eye models.
+
+    .. note::
+       This surface does not modify the optical system, i.e. surfaces of the `NoSurface` type are not built
+       when calling `EyeModel.build`. This means the properties of the preceding surface, e.g. the refractive index,
+       will propagate to the next surface.
     """
 
+    # Thickness is present on all surface instances, but cannot be set from the constructor.
     thickness: int = field(default=0, init=False)
 
 

--- a/visisipy/models/geometry.py
+++ b/visisipy/models/geometry.py
@@ -14,6 +14,7 @@ from visisipy.wavefront import ZernikeCoefficients
 __all__ = (
     "EyeGeometry",
     "NavarroGeometry",
+    "NoSurface",
     "StandardSurface",
     "Stop",
     "Surface",
@@ -206,6 +207,16 @@ class ZernikeStandardPhaseSurface(StandardSurface):
             raise ValueError("The Zernike coefficients contain terms that are greater than the maximum term.")
 
         self.zernike_coefficients = ZernikeCoefficients(self.zernike_coefficients)
+
+
+@dataclass
+class NoSurface(Surface):
+    """A surface that does not exist.
+
+    This surface is used to indicate that a surface is not present in the optical system.
+    """
+
+    thickness: int = field(default=0, init=False)
 
 
 class EyeGeometry:

--- a/visisipy/opticstudio/models.py
+++ b/visisipy/opticstudio/models.py
@@ -214,12 +214,16 @@ class OpticStudioEye(BaseOpticStudioEye):
         if object_distance != float("inf"):
             oss.LDE.GetSurfaceAt(start_from_index).Thickness = object_distance
 
-        self.cornea_front.build(oss, position=start_from_index + 1, replace_existing=replace_existing)
-        self.cornea_back.build(oss, position=start_from_index + 2, replace_existing=replace_existing)
-        self.pupil.build(oss, position=start_from_index + 3, replace_existing=True)
-        self.lens_front.build(oss, position=start_from_index + 4, replace_existing=replace_existing)
-        self.lens_back.build(oss, position=start_from_index + 5, replace_existing=replace_existing)
-        self.retina.build(oss, position=start_from_index + 6, replace_existing=True)
+        cornea_front_index = self.cornea_front.build(
+            oss, position=start_from_index + 1, replace_existing=replace_existing
+        )
+        cornea_back_index = self.cornea_back.build(
+            oss, position=cornea_front_index + 1, replace_existing=replace_existing
+        )
+        pupil_index = self.pupil.build(oss, position=cornea_back_index + 1, replace_existing=True)
+        lens_front_index = self.lens_front.build(oss, position=pupil_index + 1, replace_existing=replace_existing)
+        lens_back_index = self.lens_back.build(oss, position=lens_front_index + 1, replace_existing=replace_existing)
+        self.retina.build(oss, position=lens_back_index + 1, replace_existing=True)
 
         # Sanity checks
         if not self.pupil.surface.IsStop:

--- a/visisipy/opticstudio/surfaces.py
+++ b/visisipy/opticstudio/surfaces.py
@@ -10,7 +10,9 @@ from warnings import warn
 import zospy as zp
 
 from visisipy.models import BaseSurface
+from visisipy.models import NoSurface as OpticStudioNoSurface
 from visisipy.models.geometry import (
+    NoSurface,
     StandardSurface,
     Stop,
     Surface,
@@ -629,3 +631,12 @@ def _make_surface(
         number_of_terms=surface.maximum_term,
         norm_radius=surface.norm_radius,
     )
+
+
+@make_surface.register
+def _make_surface(
+    surface: NoSurface,  # noqa: ARG001
+    material: None = None,  # noqa: ARG001
+    comment: str = "",  # noqa: ARG001
+) -> OpticStudioNoSurface:
+    return OpticStudioNoSurface()

--- a/visisipy/opticstudio/surfaces.py
+++ b/visisipy/opticstudio/surfaces.py
@@ -187,7 +187,7 @@ class OpticStudioSurface(BaseSurface):
         if self.surface is not None and self.surface.Type != surface_type:
             zp.functions.lde.surface_change_type(self.surface, self._TYPE)
 
-    def build(self, oss: OpticStudioSystem, *, position: int, replace_existing: bool = False):
+    def build(self, oss: OpticStudioSystem, *, position: int, replace_existing: bool = False) -> int:
         """Create the surface in OpticStudio.
 
         Create the surface in the provided `OpticStudioSystem` `oss` at index `position`.
@@ -202,6 +202,11 @@ class OpticStudioSurface(BaseSurface):
             Index at which the surface is located, starting at 0 for the object surface.
         replace_existing : bool
             If `True`, replace an existing surface instead of inserting a new one. Defaults to `False`.
+
+        Returns
+        -------
+        int
+            The index of the created surface. Subsequent surfaces should be added after this index.
         """
         self._surface = oss.LDE.GetSurfaceAt(position) if replace_existing else oss.LDE.InsertNewSurfaceAt(position)
 
@@ -228,6 +233,8 @@ class OpticStudioSurface(BaseSurface):
             )
 
         self._is_built = True
+
+        return self.surface.SurfaceNumber
 
     def relink_surface(self, oss: OpticStudioSystem) -> bool:
         """Link an OpticStudio surface based on its comment.
@@ -354,7 +361,7 @@ class BaseOpticStudioZernikeSurface(OpticStudioSurface, ABC):
 
         self.surface.SurfaceData.SetNthZernikeCoefficient(n, value)
 
-    def build(self, oss: OpticStudioSystem, *, position: int, replace_existing: bool = False):
+    def build(self, oss: OpticStudioSystem, *, position: int, replace_existing: bool = False) -> int:
         """Create the surface in OpticStudio.
 
         Create the surface in the provided `OpticStudioSystem` `oss` at index `position`.
@@ -369,14 +376,21 @@ class BaseOpticStudioZernikeSurface(OpticStudioSurface, ABC):
             Index at which the surface is located, starting at 0 for the object surface.
         replace_existing : bool
             If `True`, replace an existing surface instead of inserting a new one. Defaults to `False`.
+
+        Returns
+        -------
+        int
+            The index of the created surface. Subsequent surfaces should be added after this index.
         """
-        super().build(oss, position=position, replace_existing=replace_existing)
+        index = super().build(oss, position=position, replace_existing=replace_existing)
 
         self.number_of_terms = self._number_of_terms
         self.norm_radius = self._norm_radius
 
         for n, value in self._zernike_coefficients.items():
             self.set_zernike_coefficient(n, value)
+
+        return index
 
 
 class OpticStudioZernikeStandardSagSurface(BaseOpticStudioZernikeSurface):
@@ -422,7 +436,7 @@ class OpticStudioZernikeStandardSagSurface(BaseOpticStudioZernikeSurface):
     zernike_decenter_x: float = OpticStudioSurfaceDataProperty("ZernikeDecenter_X")
     zernike_decenter_y: float = OpticStudioSurfaceDataProperty("ZernikeDecenter_Y")
 
-    def build(self, oss: OpticStudioSystem, *, position: int, replace_existing: bool = False):
+    def build(self, oss: OpticStudioSystem, *, position: int, replace_existing: bool = False) -> int:
         """Create the surface in OpticStudio.
 
         Create the surface in the provided `OpticStudioSystem` `oss` at index `position`.
@@ -437,12 +451,19 @@ class OpticStudioZernikeStandardSagSurface(BaseOpticStudioZernikeSurface):
             Index at which the surface is located, starting at 0 for the object surface.
         replace_existing : bool
             If `True`, replace an existing surface instead of inserting a new one. Defaults to `False`.
+
+        Returns
+        -------
+        int
+            The index of the created surface. Subsequent surfaces should be added after this index.
         """
-        super().build(oss, position=position, replace_existing=replace_existing)
+        index = super().build(oss, position=position, replace_existing=replace_existing)
 
         self.extrapolate = self._extrapolate
         self.zernike_decenter_x = self._zernike_decenter_x
         self.zernike_decenter_y = self._zernike_decenter_y
+
+        return index
 
 
 class OpticStudioZernikeStandardPhaseSurface(BaseOpticStudioZernikeSurface):
@@ -485,7 +506,7 @@ class OpticStudioZernikeStandardPhaseSurface(BaseOpticStudioZernikeSurface):
     extrapolate: int = OpticStudioSurfaceDataProperty("Extrapolate")
     diffract_order: float = OpticStudioSurfaceDataProperty("DiffractOrder")
 
-    def build(self, oss: OpticStudioSystem, *, position: int, replace_existing: bool = False):
+    def build(self, oss: OpticStudioSystem, *, position: int, replace_existing: bool = False) -> int:
         """Create the surface in OpticStudio.
 
         Create the surface in the provided `OpticStudioSystem` `oss` at index `position`.
@@ -500,11 +521,18 @@ class OpticStudioZernikeStandardPhaseSurface(BaseOpticStudioZernikeSurface):
             Index at which the surface is located, starting at 0 for the object surface.
         replace_existing : bool
             If `True`, replace an existing surface instead of inserting a new one. Defaults to `False`.
+
+        Returns
+        -------
+        int
+            The index of the created surface. Subsequent surfaces should be added after this index.
         """
-        super().build(oss, position=position, replace_existing=replace_existing)
+        index = super().build(oss, position=position, replace_existing=replace_existing)
 
         self.extrapolate = self._extrapolate
         self.diffract_order = self._diffract_order
+
+        return index
 
 
 @singledispatch

--- a/visisipy/optiland/models.py
+++ b/visisipy/optiland/models.py
@@ -119,16 +119,20 @@ class OptilandEye(BaseEye):
             message = "'start_from_index' can be at most the index of the last surface in the system."
             raise ValueError(message)
 
-        self.cornea_front.build(optic, position=start_from_index + 1, replace_existing=replace_existing)
-        self.cornea_back.build(optic, position=start_from_index + 2, replace_existing=replace_existing)
-        _pupil_index = start_from_index + 3
-        self.pupil.build(optic, position=_pupil_index, replace_existing=replace_existing)
-        self.lens_front.build(optic, position=start_from_index + 4, replace_existing=replace_existing)
-        self.lens_back.build(optic, position=start_from_index + 5, replace_existing=replace_existing)
-        self.retina.build(optic, position=start_from_index + 6, replace_existing=replace_existing)
+        cornea_front_index = self.cornea_front.build(
+            optic, position=start_from_index + 1, replace_existing=replace_existing
+        )
+        cornea_back_index = self.cornea_back.build(
+            optic, position=cornea_front_index + 1, replace_existing=replace_existing
+        )
+        pupil_index = cornea_back_index + 1
+        pupil_index = self.pupil.build(optic, position=pupil_index, replace_existing=replace_existing)
+        lens_front_index = self.lens_front.build(optic, position=pupil_index + 1, replace_existing=replace_existing)
+        lens_back_index = self.lens_back.build(optic, position=lens_front_index + 1, replace_existing=replace_existing)
+        self.retina.build(optic, position=lens_back_index + 1, replace_existing=replace_existing)
 
         # Sanity checks
-        if optic.surface_group.stop_index != _pupil_index:
+        if optic.surface_group.stop_index != pupil_index:
             message = "The pupil is not located at the stop position."
             raise ValueError(message)
 

--- a/visisipy/optiland/surfaces.py
+++ b/visisipy/optiland/surfaces.py
@@ -11,7 +11,9 @@ import optiland.materials
 from optiland.materials import AbbeMaterial, IdealMaterial, Material
 
 from visisipy.models import BaseSurface
+from visisipy.models import NoSurface as OptilandNoSurface
 from visisipy.models.geometry import (
+    NoSurface,
     StandardSurface,
     Stop,
     Surface,
@@ -341,3 +343,12 @@ def _make_surface(
     comment: str = "",
 ) -> OptilandSurface:
     raise NotImplementedError("ZernikeStandardPhaseSurface is not supported in Optiland.")
+
+
+@make_surface.register
+def _make_surface(
+    surface: NoSurface,  # noqa: ARG001
+    material: None = None,  # noqa: ARG001
+    comment: str = "",  # noqa: ARG001
+) -> OptilandNoSurface:
+    return OptilandNoSurface()

--- a/visisipy/optiland/surfaces.py
+++ b/visisipy/optiland/surfaces.py
@@ -226,7 +226,7 @@ class OptilandSurface(BaseSurface):
 
         raise TypeError("'material' must be MaterialModel or str.")
 
-    def build(self, optic: Optic, *, position: int, replace_existing: bool = False):
+    def build(self, optic: Optic, *, position: int, replace_existing: bool = False) -> int:
         """Create the surface in Optiland.
 
         Create the surface in the provided `Optic` object at the specified `position`.
@@ -241,6 +241,11 @@ class OptilandSurface(BaseSurface):
             The index at which the surface will be added, starting at 0 for the object surface.
         replace_existing : bool
             If `True`, replace an existing surface instead of inserting a new one. Defaults to `False`.
+
+        Returns
+        -------
+        int
+            The index of the created surface. Subsequent surfaces should be after this index.
         """
         optic.add_surface(
             index=position,
@@ -263,6 +268,8 @@ class OptilandSurface(BaseSurface):
         self._optic = weakref.proxy(optic)
         self._index = position
         self._is_built = True
+
+        return position
 
 
 @singledispatch


### PR DESCRIPTION
Currently, `Surface.build` is assumed to add 1 surface to the optical system. The eye model building methods create all surfaces at subsequent indices, e.g. the cornea front at 1, the cornea back at 2, the pupil at 3, etc.
This PR modifies the model building logic:

- `Surface.build` now returns the index of the surface _after_ which new surfaces should be added;
- `OpticStudioEye.build` and `OptilandEye.build` now use this returned index _n_ and build the next surface at index _n + 1_.

This allows to add more complex 'surfaces' in the future, that consist of an assembly of surfaces.
An example use of the new behavior is also included in this PR: `NoSurface` allows to omit a surface from the eye model. This was technically already possible by using a dummy surface (radius of $\infty$, refractive index equal to that of the preceding surface), but not inserting a dummy surface is cleaner.