### PR TITLE
Add readme to PyPI releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "visisipy"
 description = "Accessible vision simulations in Python."
+readme = "README.md"
 authors = [
     { name = "Corné Haasjes" },
     { name = "Jan-Willem Beenakker" },


### PR DESCRIPTION
I noticed PyPI does not show the readme because it is missing from the metadata. This PR should fix that.