### PR TITLE
Refactor `create_geometry` and add support for retina half axes and nonzero pupil thickness

### DIFF
--- a/example.py
+++ b/example.py
@@ -77,7 +77,7 @@ class InputOutputAngles(NamedTuple):
 
 location_np2 = 7.45 - (model.geometry.cornea_thickness + model.geometry.anterior_chamber_depth)
 location_retina_center = (
-    model.geometry.lens_thickness + model.geometry.vitreous_thickness - abs(model.geometry.retina.half_axes.axial)
+    model.geometry.lens_thickness + model.geometry.vitreous_thickness - abs(model.geometry.retina.ellipsoid_radii.z)
 )
 
 angles = pd.DataFrame(

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -180,6 +180,7 @@ class TestCreateGeometry:
         assert isinstance(geometry.cornea_back.thickness, SentinelFloat)
 
         assert isinstance(geometry.pupil.semi_diameter, SentinelFloat)
+        assert isinstance(geometry.pupil.thickness, SentinelFloat)
 
         assert isinstance(geometry.lens_front.thickness, SentinelFloat)
         assert isinstance(geometry.lens_front.radius, SentinelFloat)

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -253,9 +253,7 @@ class TestCreateGeometry:
     ):
         parameters = parameters_a | parameters_b
 
-        with pytest.raises(
-            ValueError, match="Cannot specify both retina radius/asphericity and ellipsoid radii"
-        ):
+        with pytest.raises(ValueError, match="Cannot specify both retina radius/asphericity and ellipsoid radii"):
             create_geometry(base=base_geometry, **parameters)
 
     @pytest.mark.parametrize(

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -145,6 +145,9 @@ class TestEyeGeometry:
     def test_anterior_chamber_depth(self, example_geometry_parameters, example_geometry):
         assert example_geometry.anterior_chamber_depth == example_geometry_parameters["anterior_chamber_depth"]
 
+    def test_pupil_lens_distance(self, example_geometry_parameters, example_geometry):
+        assert example_geometry.pupil_lens_distance == example_geometry_parameters["pupil_lens_distance"]
+
     def test_lens_thickness(self, example_geometry_parameters, example_geometry):
         assert example_geometry.lens_thickness == example_geometry_parameters["lens_thickness"]
 
@@ -152,6 +155,7 @@ class TestEyeGeometry:
         vitreous_thickness = example_geometry_parameters["axial_length"] - (
             example_geometry_parameters["cornea_thickness"]
             + example_geometry_parameters["anterior_chamber_depth"]
+            + example_geometry_parameters["pupil_lens_distance"]
             + example_geometry_parameters["lens_thickness"]
         )
         assert example_geometry.vitreous_thickness == vitreous_thickness

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -247,7 +247,7 @@ class TestCreateGeometry:
             {"retina_axial_half_axis": 12, "retina_radial_half_axis": 12},
         ],
     )
-    def test_supplying_retina_parameters_and_half_axes_raises_valeuerror(
+    def test_supplying_retina_parameters_and_half_axes_raises_valueerror(
         self, base_geometry, parameters_a, parameters_b
     ):
         parameters = parameters_a | parameters_b

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -72,26 +72,27 @@ def example_geometry(example_geometry_parameters):
 
 class TestStandardSurface:
     @pytest.mark.parametrize(
-        "radius,asphericity,axial_half_axis,radial_half_axis",
+        "radius,asphericity,z_radius,y_radius",
         [
             (12, 0, 12, 12),
             (12, 1, 6, 12 / np.sqrt(2)),
             (12, -0.5, 24, 12 / np.sqrt(0.5)),
         ],
     )
-    def test_half_axes(self, radius, asphericity, axial_half_axis, radial_half_axis):
+    def test_ellipsoid_radii(self, radius, asphericity, z_radius, y_radius):
         surface = StandardSurface(radius=radius, asphericity=asphericity)
 
-        assert surface.half_axes == pytest.approx((axial_half_axis, radial_half_axis))
-        assert surface.half_axes.axial == pytest.approx(axial_half_axis)
-        assert surface.half_axes.radial == pytest.approx(radial_half_axis)
+        assert surface.ellipsoid_radii == pytest.approx((z_radius, y_radius, y_radius))
+        assert surface.ellipsoid_radii.z == pytest.approx(z_radius)
+        assert surface.ellipsoid_radii.y == pytest.approx(y_radius)
+        assert surface.ellipsoid_radii.x == pytest.approx(y_radius)
 
     @pytest.mark.parametrize("asphericity", [-1, -1.5])
-    def test_half_axes_raises_notimplementederror(self, asphericity):
+    def test_ellipsoid_radii_raises_notimplementederror(self, asphericity):
         surface = StandardSurface(radius=12, asphericity=asphericity)
 
         with pytest.raises(NotImplementedError):
-            _ = surface.half_axes
+            _ = surface.ellipsoid_radii
 
 
 class TestStop:
@@ -242,9 +243,9 @@ class TestCreateGeometry:
     @pytest.mark.parametrize(
         "parameters_b",
         [
-            {"retina_axial_half_axis": 12},
-            {"retina_radial_half_axis": 12},
-            {"retina_axial_half_axis": 12, "retina_radial_half_axis": 12},
+            {"retina_ellipsoid_z_radius": 12},
+            {"retina_ellipsoid_y_radius": 12},
+            {"retina_ellipsoid_z_radius": 12, "retina_ellipsoid_y_radius": 12},
         ],
     )
     def test_supplying_retina_parameters_and_half_axes_raises_valueerror(
@@ -253,21 +254,21 @@ class TestCreateGeometry:
         parameters = parameters_a | parameters_b
 
         with pytest.raises(
-            ValueError, match="Cannot specify both retina radius/asphericity and axial/radial half axes"
+            ValueError, match="Cannot specify both retina radius/asphericity and ellipsoid radii"
         ):
             create_geometry(base=base_geometry, **parameters)
 
     @pytest.mark.parametrize(
         "parameters",
         [
-            {"retina_axial_half_axis": 12},
-            {"retina_radial_half_axis": 12},
+            {"retina_ellipsoid_z_radius": 12},
+            {"retina_ellipsoid_y_radius": 12},
         ],
     )
     def test_supplying_single_half_axis_raises_valueerror(self, base_geometry, parameters):
         with pytest.raises(
             ValueError,
-            match="If the retina half axes are specified, both axial and radial half axes must be provided",
+            match="If the retina ellipsoid radii are specified, both the z and y radius must be provided",
         ):
             create_geometry(base=base_geometry, **parameters)
 
@@ -310,8 +311,9 @@ class TestCreateGeometry:
                 lens_thickness=5,
             )
 
-    def test_set_retina_half_axes(self, base_geometry):
-        geometry = create_geometry(base=base_geometry, retina_axial_half_axis=12.34, retina_radial_half_axis=10)
+    def test_set_retina_ellipsoid_radii(self, base_geometry):
+        geometry = create_geometry(base=base_geometry, retina_ellipsoid_z_radius=12.34, retina_ellipsoid_y_radius=10)
 
-        assert pytest.approx(geometry.retina.half_axes.axial) == 12.34
-        assert pytest.approx(geometry.retina.half_axes.radial) == 10
+        assert pytest.approx(geometry.retina.ellipsoid_radii.z) == 12.34
+        assert pytest.approx(geometry.retina.ellipsoid_radii.y) == 10
+        assert pytest.approx(geometry.retina.ellipsoid_radii.x) == 10

--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -161,7 +161,7 @@ class TestEyeGeometry:
 class TestCreateGeometry:
     def test_create_geometry(self, base_geometry, example_geometry_parameters, example_geometry):
         class SentinelFloat(float):
-            """Custom float class to mark floats as set by a unit test"""
+            """Custom float class to mark floats as set by a unit test."""
 
         geometry = create_geometry(
             base=base_geometry,

--- a/visisipy/models/geometry.py
+++ b/visisipy/models/geometry.py
@@ -595,7 +595,9 @@ def create_geometry(
         warn("The cornea back radius was provided, but it will be ignored because estimate_cornea_back is True.")
 
     has_retina_radius_or_asphericity = ("retina_radius" in parameters) or ("retina_asphericity" in parameters)
-    has_retina_ellipsoid_radii = ("retina_ellipsoid_z_radius" in parameters) or ("retina_ellipsoid_y_radius" in parameters)
+    has_retina_ellipsoid_radii = ("retina_ellipsoid_z_radius" in parameters) or (
+        "retina_ellipsoid_y_radius" in parameters
+    )
 
     if has_retina_radius_or_asphericity and has_retina_ellipsoid_radii:
         raise ValueError("Cannot specify both retina radius/asphericity and ellipsoid radii.")


### PR DESCRIPTION
- Specify parameters for `create_geometry` as a `TypedDict`
- Add new `retina_axial_half_axis` and `retina_radial_half_axis` parameters to configure the retina using its half axes instead of its radius and asphericity. A `ValueError` is raised if both a radius / asphericity and a half axis are specified, or if only a single half axis is specified.
- Add a new `pupil_lens_distance` parameter to `create_geometry` and a property with the same name to `EyeGeometry`, to allow for a nonzero distance between the pupil and the lens.

@jwmbeenakker do you agree with the names of the new parameters, or do you prefer different names?