### PR TITLE
Add FFT PSF analysis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ dependencies = [
     "optiland>=0.4.1",
     "scipy",
     "typing-extensions>=4.12.2 ; python_full_version < '3.11'",
-    "zospy",
-    "zospy>=2.0.2; sys_platform == 'win32'",
+    "zospy>=2.1.0; sys_platform == 'win32'",
 ]
 requires-python = ">=3.9, <3.14"
 dynamic = ["version"]
@@ -121,6 +120,3 @@ max-line-length = 120
 max-summary-lines = 1
 summary-quotes-same-line = true
 linewrap-full-docstring = true
-
-[tool.uv.sources]
-zospy = { git = "https://github.com/MREYE-LUMC/ZOSPy", rev = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "optiland>=0.4.1",
     "scipy",
     "typing-extensions>=4.12.2 ; python_full_version < '3.11'",
+    "zospy",
     "zospy>=2.0.2; sys_platform == 'win32'",
 ]
 requires-python = ">=3.9, <3.14"
@@ -120,3 +121,6 @@ max-line-length = 120
 max-summary-lines = 1
 summary-quotes-same-line = true
 linewrap-full-docstring = true
+
+[tool.uv.sources]
+zospy = { git = "https://github.com/MREYE-LUMC/ZOSPy", rev = "main" }

--- a/tests/analysis/test_analyses.py
+++ b/tests/analysis/test_analyses.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
 import visisipy
 import visisipy.backend
 
@@ -10,6 +14,9 @@ class MockAnalysis:
         surface_1,
         surface_2,
     ):
+        return None, None
+
+    def fft_psf(self, field_coordinate, wavelength, field_type, sampling, psf_type):
         return None, None
 
     def raytrace(
@@ -47,6 +54,21 @@ def test_cardinal_points_analysis(monkeypatch):
 
     assert visisipy.analysis.cardinal_points() is None
     assert visisipy.analysis.cardinal_points(return_raw_result=True) == (None, None)
+
+
+@pytest.mark.parametrize(
+    "psf_type,expectation",
+    [
+        ("linear", does_not_raise()),
+        ("logarithmic", does_not_raise()),
+        ("invalid", pytest.raises(ValueError, match="psf_type must be either 'linear' or 'logarithmic'")),
+    ],
+)
+def test_fft_psf_analysis(monkeypatch, psf_type, expectation):
+    monkeypatch.setattr(visisipy.backend, "_BACKEND", MockBackend)
+
+    assert visisipy.analysis.fft_psf() is None
+    assert visisipy.analysis.fft_psf(return_raw_result=True) == (None, None)
 
 
 def test_raytracing_analysis(monkeypatch):

--- a/tests/opticstudio/analysis/test_psf.py
+++ b/tests/opticstudio/analysis/test_psf.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from visisipy import EyeModel
+
+pytestmark = [pytest.mark.needs_opticstudio]
+
+
+class TestFFTPSFAnalysis:
+    @pytest.mark.parametrize(
+        "field_coordinate,wavelength,field_type,sampling,psf_type,expectation",
+        [
+            (None, None, "angle", 32, "linear", does_not_raise()),
+            (None, None, "object_height", 64, "logarithmic", does_not_raise()),
+            ((0, 0), 0.550, "angle", 128, "linear", does_not_raise()),
+            ((10, 5), 0.400, "object_height", 256, "logarithmic", does_not_raise()),
+            ((5.5, 5.5), 0.550, "angle", 512, "linear", does_not_raise()),
+            (
+                None,
+                None,
+                "object_height",
+                64,
+                "quadratic",
+                pytest.raises(ValueError, match=re.escape("Invalid PSF type. Must be 'linear' or 'logarithmic'.")),
+            ),
+        ],
+    )
+    def test_fft_psf(
+        self,
+        opticstudio_backend,
+        opticstudio_analysis,
+        field_coordinate,
+        wavelength,
+        field_type,
+        sampling,
+        psf_type,
+        expectation,
+    ):
+        opticstudio_backend.build_model(
+            EyeModel(), object_distance=10 if field_type == "object_height" else float("inf")
+        )
+
+        with expectation:
+            assert opticstudio_analysis.fft_psf(
+                field_coordinate=field_coordinate,
+                wavelength=wavelength,
+                field_type=field_type,
+                sampling=sampling,
+                psf_type=psf_type,
+            )

--- a/tests/optiland/analysis/test_psf.py
+++ b/tests/optiland/analysis/test_psf.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import re
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from visisipy import EyeModel
+
+
+class TestFFTPSFAnalysis:
+    @pytest.mark.parametrize(
+        "field_coordinate,wavelength,field_type,sampling,psf_type,expectation",
+        [
+            (None, None, "angle", 32, "linear", does_not_raise()),
+            (None, None, "object_height", 64, "logarithmic", does_not_raise()),
+            ((0, 0), 0.550, "angle", 128, "linear", does_not_raise()),
+            ((10, 5), 0.400, "object_height", 256, "logarithmic", does_not_raise()),
+            ((5.5, 5.5), 0.550, "angle", 512, "linear", does_not_raise()),
+            (
+                None,
+                None,
+                "object_height",
+                64,
+                "quadratic",
+                pytest.raises(ValueError, match=re.escape("Invalid PSF type. Choose 'linear' or 'logarithmic'")),
+            ),
+        ],
+    )
+    def test_fft_psf(
+        self,
+        optiland_backend,
+        optiland_analysis,
+        field_coordinate,
+        wavelength,
+        field_type,
+        sampling,
+        psf_type,
+        expectation,
+    ):
+        optiland_backend.build_model(EyeModel(), object_distance=10 if field_type == "object_height" else float("inf"))
+
+        with expectation:
+            assert optiland_analysis.fft_psf(
+                field_coordinate=field_coordinate,
+                wavelength=wavelength,
+                field_type=field_type,
+                sampling=sampling,
+                psf_type=psf_type,
+            )

--- a/tests/optiland/analysis/test_psf.py
+++ b/tests/optiland/analysis/test_psf.py
@@ -23,7 +23,7 @@ class TestFFTPSFAnalysis:
                 "object_height",
                 64,
                 "quadratic",
-                pytest.raises(ValueError, match=re.escape("Invalid PSF type. Choose 'linear' or 'logarithmic'")),
+                pytest.raises(ValueError, match=re.escape("Invalid PSF type. Must be 'linear' or 'logarithmic'")),
             ),
         ],
     )

--- a/visisipy/analysis/__init__.py
+++ b/visisipy/analysis/__init__.py
@@ -17,10 +17,11 @@ The backend parameter is also optional; if no backend is provided, the current o
 from __future__ import annotations
 
 from visisipy.analysis.cardinal_points import cardinal_points
+from visisipy.analysis.psf import fft_psf
 from visisipy.analysis.raytracing import raytrace
 from visisipy.analysis.refraction import refraction
 from visisipy.analysis.zernike_standard_coefficients import (
     zernike_standard_coefficients,
 )
 
-__all__ = ("cardinal_points", "raytrace", "refraction", "zernike_standard_coefficients")
+__all__ = ("cardinal_points", "fft_psf", "raytrace", "refraction", "zernike_standard_coefficients")

--- a/visisipy/analysis/psf.py
+++ b/visisipy/analysis/psf.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, overload
+
+from visisipy.analysis.base import _AUTOMATIC_BACKEND, analysis
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
+
+    from visisipy import EyeModel
+    from visisipy.backend import BaseBackend
+    from visisipy.types import FieldCoordinate, FieldType, SampleSize
+
+
+@overload
+def fft_psf(
+    model: EyeModel | None = None,
+    field_coordinate: FieldCoordinate | None = None,
+    wavelength: float | None = None,
+    field_type: FieldType = "angle",
+    sampling: SampleSize | str | int = 64,
+    psf_type: Literal["linear", "logarithmic"] = "linear",
+    *,
+    return_raw_result: Literal[False] = False,
+    backend: type[BaseBackend] = _AUTOMATIC_BACKEND,
+) -> DataFrame: ...
+
+
+@overload
+def fft_psf(
+    model: EyeModel | None = None,
+    field_coordinate: FieldCoordinate | None = None,
+    wavelength: float | None = None,
+    field_type: FieldType = "angle",
+    sampling: SampleSize | str | int = 64,
+    psf_type: Literal["linear", "logarithmic"] = "linear",
+    *,
+    return_raw_result: Literal[True] = True,
+    backend: type[BaseBackend] = _AUTOMATIC_BACKEND,
+) -> tuple[DataFrame, Any]: ...
+
+
+@analysis
+def fft_psf(
+    model: EyeModel | None = None,  # noqa: ARG001
+    field_coordinate: FieldCoordinate | None = None,
+    wavelength: float | None = None,
+    field_type: FieldType = "angle",
+    sampling: SampleSize | str | int = 64,
+    psf_type: Literal["linear", "logarithmic"] = "linear",
+    *,
+    return_raw_result: bool = False,  # noqa: ARG001
+    backend: type[BaseBackend] = _AUTOMATIC_BACKEND,
+) -> tuple[DataFrame, Any]:
+    """Calculate the FFT Point Spread Function (PSF) at the retina surface.
+
+    Parameters
+    ----------
+    model : EyeModel | None
+        The eye model to be used in the ray trace. If `None`, the current eye model will be used.
+    field_coordinate : FieldCoordinate | None
+        The field coordinate at which the PSF is calculated. If `None`, the first field coordinate in the backend is
+        used.
+    wavelength : float | None
+        The wavelength at which the PSF is calculated. If `None`, the first wavelength in the backend is used.
+    field_type : FieldType
+        The field type to be used in the analysis. Can be either "angle" or "object_height". Defaults to "angle".
+        This parameter is only used when `field_coordinate` is specified.
+    sampling : SampleSize | str | int
+        The size of the ray grid used to sample the pupil. Can be an integer or a string in the format "NxN", where N
+        is an integer. Only symmetric sample sizes are supported. Defaults to 64.
+    psf_type : Literal["linear", "logarithmic"]
+        The PSF normalization type. Can be either "linear" or "logarithmic". Defaults to "linear".
+    return_raw_result : bool, optional
+        Return the raw analysis result from the backend. Defaults to `False`.
+    backend : type[BaseBackend]
+        The backend to be used for the analysis. If not provided, the default backend is used.
+
+    Returns
+    -------
+    DataFrame
+        The PSF data as a DataFrame. The DataFrame contains the PSF values at the specified field coordinate and
+        wavelength.
+    """
+    if psf_type not in {"linear", "logarithmic"}:
+        raise ValueError("psf_type must be either 'linear' or 'logarithmic'.")
+
+    return backend.analysis.fft_psf(
+        field_coordinate=field_coordinate,
+        wavelength=wavelength,
+        field_type=field_type,
+        sampling=sampling,
+        psf_type=psf_type,
+    )

--- a/visisipy/backend.py
+++ b/visisipy/backend.py
@@ -131,6 +131,16 @@ class BaseAnalysisRegistry(ABC):
     ) -> tuple[CardinalPointsResult, Any]: ...
 
     @abstractmethod
+    def fft_psf(
+        self,
+        field_coordinate: FieldCoordinate | None = None,
+        wavelength: float | None = None,
+        field_type: FieldType = "angle",
+        sampling: SampleSize | str | int = 64,
+        psf_type: Literal["linear", "logarithmic"] = "linear",
+    ) -> tuple[DataFrame, Any]: ...
+
+    @abstractmethod
     def raytrace(
         self,
         coordinates: Iterable[FieldCoordinate] | None = None,

--- a/visisipy/opticstudio/analysis/__init__.py
+++ b/visisipy/opticstudio/analysis/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from visisipy.backend import BaseAnalysisRegistry, _AnalysisMethod
 from visisipy.opticstudio.analysis.cardinal_points import cardinal_points
+from visisipy.opticstudio.analysis.psf import fft_psf
 from visisipy.opticstudio.analysis.raytrace import raytrace
 from visisipy.opticstudio.analysis.refraction import refraction
 from visisipy.opticstudio.analysis.zernike_coefficients import (
@@ -26,6 +27,7 @@ class OpticStudioAnalysisRegistry(BaseAnalysisRegistry):
         self._oss = backend.oss
 
     cardinal_points = _AnalysisMethod(cardinal_points)
+    fft_psf = _AnalysisMethod(fft_psf)
     raytrace = _AnalysisMethod(raytrace)
     zernike_standard_coefficients = _AnalysisMethod(zernike_standard_coefficients)
     refraction = _AnalysisMethod(refraction)

--- a/visisipy/opticstudio/analysis/psf.py
+++ b/visisipy/opticstudio/analysis/psf.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import zospy as zp
+
+from visisipy.types import FieldCoordinate, FieldType, SampleSize
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from visisipy.opticstudio import OpticStudioBackend
+
+
+def fft_psf(
+    backend: type[OpticStudioBackend],
+    field_coordinate: FieldCoordinate | None = None,
+    wavelength: float | None = None,
+    field_type: FieldType = "angle",
+    sampling: SampleSize | str | int = 64,
+    psf_type: Literal["linear", "logarithmic"] = "linear",
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Calculate the FFT Point Spread Function (PSF) at the retina surface.
+
+    Parameters
+    ----------
+    backend : type[OpticStudioBackend]
+        Reference to the OpticStudio backend.
+    field_coordinate : tuple[float, float], optional
+        The field coordinate (x, y) in mm. If `None`, the first field in OpticStudio is used. Defaults to `None`.
+    wavelength : float, optional
+        The wavelength in μm. If `None`, the first wavelength in OpticStudio is used. Defaults to `None`.
+    field_type : Literal["angle", "object_height"], optional
+        The field type. Either "angle" or "object_height". Defaults to "angle". This parameter is only used if
+        `field_coordinate` is not `None`.
+    sampling : SampleSize | str | int, optional
+        The size of the ray grid used to sample the pupil, either string (e.g. '32x32') or int (e.g. 32). Defaults to 64.
+    psf_type : Literal["linear", "logarithmic"], optional
+        The PSF normalization type. Either "linear" or "logarithmic". Defaults to "linear".
+
+    Returns
+    -------
+    DataFrame
+        The PSF data as a pandas DataFrame.
+
+    Raises
+    ------
+    ValueError
+        If the `psf_type` is not "linear" or "logarithmic".
+    """
+    if psf_type == "linear":
+        psf_type = zp.constants.Analysis.Settings.Psf.FftPsfType.Linear
+    elif psf_type == "logarithmic":
+        psf_type = zp.constants.Analysis.Settings.Psf.FftPsfType.Log
+    else:
+        raise ValueError("Invalid PSF type. Must be 'linear' or 'logarithmic'.")
+
+    if not isinstance(sampling, SampleSize):
+        sampling = SampleSize(sampling)
+
+    # TODO: create helper for setting wavelengths and fields, because this code is duplicated in other analyses
+    wavelength_number = 1 if wavelength is None else backend.get_wavelength_number(wavelength)
+
+    if wavelength_number is None:
+        backend.set_wavelengths([wavelength])
+        wavelength_number = 1
+
+    if field_coordinate is not None:
+        backend.set_fields([field_coordinate], field_type=field_type)
+
+    psf_result = zp.analyses.psf.FFTPSF(
+        sampling=str(sampling),
+        display=str(2 * sampling),
+        wavelength=wavelength_number,
+        field=1,
+        psf_type=psf_type,
+        surface="Image",
+        normalize=True,
+    ).run(backend.get_oss())
+
+    return psf_result.data, psf_result.data

--- a/visisipy/optiland/analysis/__init__.py
+++ b/visisipy/optiland/analysis/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from visisipy.backend import BaseAnalysisRegistry, _AnalysisMethod
 from visisipy.optiland.analysis.cardinal_points import cardinal_points
+from visisipy.optiland.analysis.psf import fft_psf
 from visisipy.optiland.analysis.raytrace import raytrace
 from visisipy.optiland.analysis.refraction import refraction
 from visisipy.optiland.analysis.zernike_coefficients import zernike_standard_coefficients
@@ -24,6 +25,7 @@ class OptilandAnalysisRegistry(BaseAnalysisRegistry):
         self._optic = backend.optic
 
     cardinal_points = _AnalysisMethod(cardinal_points)
+    fft_psf = _AnalysisMethod(fft_psf)
     raytrace = _AnalysisMethod(raytrace)
     zernike_standard_coefficients = _AnalysisMethod(zernike_standard_coefficients)
     refraction = _AnalysisMethod(refraction)

--- a/visisipy/optiland/analysis/psf.py
+++ b/visisipy/optiland/analysis/psf.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import pandas as pd
+from optiland.psf import FFTPSF
+
+from visisipy.types import SampleSize
+
+if TYPE_CHECKING:
+    from visisipy.optiland import OptilandBackend
+    from visisipy.types import FieldCoordinate, FieldType
+
+
+def fft_psf(
+    backend: type[OptilandBackend],
+    field_coordinate: FieldCoordinate | None = None,
+    wavelength: float | None = None,
+    field_type: FieldType = "angle",
+    sampling: SampleSize | str | int = 64,
+    psf_type: Literal["linear", "logarithmic"] = "linear",
+) -> tuple[pd.DataFrame, FFTPSF]:
+    if psf_type == "linear":
+        log = False
+    elif psf_type == "logarithmic":
+        log = True  # noqa: F841
+    else:
+        raise ValueError("Invalid PSF type. Must be 'linear' or 'logarithmic'.")
+
+    if not isinstance(sampling, SampleSize):
+        sampling = SampleSize(sampling)
+
+    if field_coordinate is not None:
+        backend.set_fields([field_coordinate], field_type=field_type)
+
+    if wavelength is None:
+        wavelength = backend.get_wavelengths()[0]
+    else:
+        backend.set_wavelengths([wavelength])
+
+    normalized_field = backend.get_optic().fields.get_field_coords()[0]
+
+    psf = FFTPSF(
+        optic=backend.get_optic(),
+        field=normalized_field,
+        wavelength=wavelength,
+        num_rays=int(sampling),
+        grid_size=int(2 * sampling),
+    )
+
+    df = pd.DataFrame(psf.psf / 100)  # Optiland returns a normalized PSF in range [0, 100
+
+    return df, psf

--- a/visisipy/types.py
+++ b/visisipy/types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import sys
+from typing import Literal
 
 if sys.version_info < (3, 11):
     from typing_extensions import NotRequired, TypedDict, Unpack
@@ -14,7 +15,17 @@ else:
     from typing import NotRequired, TypedDict, Unpack
 
 
-__all__ = ("NotRequired", "SampleSize", "TypedDict", "Unpack")
+__all__ = ("ApertureType", "FieldCoordinate", "FieldType", "NotRequired", "SampleSize", "TypedDict", "Unpack")
+
+ApertureType = Literal[
+    "float_by_stop_size",
+    "entrance_pupil_diameter",
+    "image_f_number",
+    "object_numeric_aperture",
+]
+FieldType = Literal["angle", "object_height"]
+FieldCoordinate = tuple[float, float]
+
 
 RE_SAMPLE_SIZE = re.compile(r"^(?P<sampling>\d+)x(?P=sampling)$", re.IGNORECASE)
 
@@ -80,3 +91,38 @@ class SampleSize:
 
     def __repr__(self):
         return f"SampleSize({self.sampling})"
+
+    def __mul__(self, factor: int) -> SampleSize:
+        """Multiply the sample size by an integer.
+
+        Parameters
+        ----------
+        factor : int
+            The integer to multiply the sample size by.
+
+        Returns
+        -------
+        SampleSize
+            A new SampleSize object with the multiplied sample size.
+        """
+        if not isinstance(factor, int):
+            raise TypeError("SampleSize can only be multiplied by integer factors.")
+        if factor <= 0:
+            raise ValueError("SampleSize factor must be a positive integer.")
+
+        return SampleSize(self.sampling * factor)
+
+    def __rmul__(self, factor: int) -> SampleSize:
+        """Multiply the sample size by an integer.
+
+        Parameters
+        ----------
+        factor : int
+            The integer to multiply the sample size by.
+
+        Returns
+        -------
+        SampleSize
+            A new SampleSize object with the multiplied sample size.
+        """
+        return self.__mul__(factor)


### PR DESCRIPTION
Adds an FFT PSF analysis for both backends. 
I am currently unable to reproduce the OpticStudio PSF results in Optiland. This is tracked at https://github.com/HarrisonKramer/optiland/discussions/157. This PR should only be reviewed and merged after we can obtain similar results with both backends.