### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: "CI"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MREYE-LUMC/visisipy/security/code-scanning/2](https://github.com/MREYE-LUMC/visisipy/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` block to the workflow. This can be done at the workflow root level (applies to all jobs unless they define a more specific job-level `permissions` block) or per job. Since both jobs (`format` and `test`) only read repository contents and do not write to them, the minimal permission required is `contents: read`. Therefore, add the following block near the top of the workflow file (right after the workflow name, before `on:`). No changes to imports or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
