### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: "CI"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MREYE-LUMC/visisipy/security/code-scanning/3](https://github.com/MREYE-LUMC/visisipy/security/code-scanning/3)

To fix the problem, explicitly add the `permissions` block to either the workflow root (affecting all jobs) or to each job individually, specifying the minimal permissions required. The single best way in this case is to add the following block at the root, under the workflow name and before `on:`:
```yaml
permissions:
  contents: read
```
This grants only read permission to repository contents for the GITHUB_TOKEN, which suffices for the jobs shown. No other permissions (e.g. `issues: write`, `pull-requests: write`) are necessary unless there are steps that modify issues or PRs, which do not appear here.

Introduce the following changes at the top of `.github/workflows/ci.yml`, just after the workflow name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
