### PR TITLE
Check curvature signs in create_geometry

### DIFF
--- a/tests/models/test_geometry.py
+++ b/tests/models/test_geometry.py
@@ -439,6 +439,7 @@ class TestCheckSign:
             ),
         ],
     )
+    @pytest.mark.filterwarnings("error")  # Fail on unexpected warnings
     def test_check_sign(self, sign, value, expectation):
         with expectation:
             _check_sign(value, "test_param", sign)
@@ -525,6 +526,7 @@ class TestCheckSign:
             ),
         ],
     )
+    @pytest.mark.filterwarnings("error")  # Fail on unexpected warnings
     def test_create_geometry_checks_signs(self, parameter, value, expectation):
         if parameter == "retina_ellipsoid_z_radius":
             params = {"retina_ellipsoid_y_radius": 1, parameter: value}

--- a/visisipy/models/geometry.py
+++ b/visisipy/models/geometry.py
@@ -640,9 +640,9 @@ def _check_sign(value: float | None, name: str, sign: Literal["+", "-"]) -> None
 
     msg = "Expected a {} value for {}, got {}. Check if the sign is correct."
 
-    if sign == "+" and value <= 0:
+    if sign == "+" and value < 0:
         warn(msg.format("positive", name, value), UserWarning, stacklevel=2)
-    elif sign == "-" and value >= 0:
+    elif sign == "-" and value > 0:
         warn(msg.format("negative", name, value), UserWarning, stacklevel=2)
 
 


### PR DESCRIPTION
Most eye models have the same signs for radii of curvature of specific optical elements, e.g. the cornea front, cornea back and lens front radii are positive and the lens back and retina radii are negative. When automatically creating eye models, e.g. based on a data file, it is pretty easy to use the wrong file, and rather difficult to find out what went wrong because the resulting errors can be quite obscure.
I added checks to `create_geometry` to verify if the signs for these parameters match the expected signs and raise a warning if the sign is different.

@jwmbeenakker this does not check completely manually created models using `EyeGeometry`. I could add these checks to `EyeGeometry` instead, but that would be more complicated. Furthermore, `EyeGeometry` is intended to create (almost) fully customized eye models, so checking signs for all models that can be possibly created with visisipy may be undesirable. Please let me know what you prefer.