### PR TITLE
Remove numpy version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [{ name = "MReye research group", email = "zospy@mreye.nl" }]
 dependencies = [
     "matplotlib",
     "numba>=0.60.0",
-    "numpy<2.4.0",
+    "numpy",
     "optiland>=0.6.0,<0.7.0",
     "scipy",
     "typing-extensions>=4.12.2 ; python_full_version < '3.13'",


### PR DESCRIPTION
Optiland is now compatible with numpy >= 2.4.0