### PR TITLE
Remove PDF format from .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,6 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-formats:
-  - pdf
-
 python:
   install:
     - method: uv


### PR DESCRIPTION
Remove PDF format because of failing PDF builds